### PR TITLE
DOC: Add content to the lesson's overview page

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,15 +3,31 @@ layout: lesson
 root: .  # Is the only page that doesn't follow the pattern /:path/index.html
 permalink: index.html  # Is the only page that doesn't follow the pattern /:path/index.html
 ---
-FIXME: home page introduction
+This Data Carpentry lesson aims to introduce learners to the analysis of
+diffusion Magnetic Resonance Imaging (dMRI) data using primarily Python. Its
+target audience includes researchers willing to discover the dMRI field, as well
+as under-graduate or graduate students willing to broaden their skills from
+related fields, such as neuroscience, computational neuroscience, or medical
+image analysis.
 
-<!-- this is an html comment -->
-
-{% comment %} This is a comment in Liquid {% endcomment %}
-
-> ## Prerequisites
+> ## Prerequisites for instructors
 >
-> FIXME
+> This lesson assumes that the instructors have solid knowledge about diffusion
+> MRI, scientific programming tools used throughout the lesson ([see the
+BIDS-dMRI Setup page](https://carpentries-incubator.github.io/SDC-BIDS-dMRI/setup.html)),
+and teaching experience.
+> If you are teaching this lesson in a workshop, please see the [Instructor notes](./guide/index.html).
+{: .prereq}
+
+> ## Prerequisites for learners
+>
+> This lesson assumes that the learners have a basic understanding of how a
+signal or image is represented digitally, an entry-level knowledge about aspects
+linked to medical image analysis, and a minimal set of computing and programming
+skills to install the required tools and to follow the lesson ([see the
+BIDS-dMRI Setuo page](https://carpentries-incubator.github.io/SDC-BIDS-dMRI/setup.html).
+This lesson requires learners to have completed the [Introduction to MRI and BIDS carpentry](https://carpentries-incubator.github.io/SDC-BIDS-IntroMRI/)
+corresponding to the Neuroimaging Curriculum.
 {: .prereq}
 
 {% include links.md %}


### PR DESCRIPTION
Add content to the lesson's overview page:
- Introduce the lesson and its target audience.
- Add the prerequisites.
