### PR TITLE
DOC: Fix spelling and capitalize acronyms in lesson 03

### DIFF
--- a/_episodes/03-diffusion_tensor_imaging.md
+++ b/_episodes/03-diffusion_tensor_imaging.md
@@ -15,7 +15,7 @@ keypoints:
 
 ## Diffusion Tensor Imaging (DTI)
 
-Diffusion tensor imaging or "DTI" refers to images describing diffusion with a tensor model. DTI is derived from preprocessed diffusion weighted imaging (dwi) data. First proposed by Basser and colleagues ([Basser, 1994](https://www.ncbi.nlm.nih.gov/pubmed/8130344)), the diffusion tensor model describes diffusion characteristics within an imaging voxel. This model has been very influential in demonstrating the utility of the diffusion MRI in characterizing the microstructure of white matter and the biophysical properties (inferred from local diffusion properties). The DTI model is still a commonly used model to investigate white matter.
+Diffusion tensor imaging or "DTI" refers to images describing diffusion with a tensor model. DTI is derived from preprocessed diffusion weighted imaging (DWI) data. First proposed by Basser and colleagues ([Basser, 1994](https://www.ncbi.nlm.nih.gov/pubmed/8130344)), the diffusion tensor model describes diffusion characteristics within an imaging voxel. This model has been very influential in demonstrating the utility of the diffusion MRI in characterizing the microstructure of white matter and the biophysical properties (inferred from local diffusion properties). The DTI model is still a commonly used model to investigate white matter.
 
 The tensor models the diffusion signal mathematically as:
 
@@ -25,14 +25,14 @@ Where ![](../fig/3/inline_unitvector.png) is a unit vector in 3D space indicatin
 
 ![Diffusion matrix](../fig/3/diffusion_matrix.png) {:class="img-responsive"}
 
-The diffusion matrix is a variance-covariance matrix of the diffusivity along the three spatial dimensions. Note that we can assume that the diffusivity has antipodal symmetry, so elmenets across the diagonal of the matrix are equal. For example: ![](../fig/3/inline_diagelements.png). This is why there are only 6 free parameters to estimate here.
+The diffusion matrix is a variance-covariance matrix of the diffusivity along the three spatial dimensions. Note that we can assume that the diffusivity has antipodal symmetry, so elements across the diagonal of the matrix are equal. For example: ![](../fig/3/inline_diagelements.png). This is why there are only 6 free parameters to estimate here.
 
-Tensors are represented by ellipsoids characterized by calculated eigenvalues (![](../fig/3/inline_eigval.png)) and eigenvectors (![](../fig/3/inline_eigvec.png)) from the previously described matrix. The computed eigenvalues and eigenvectors are normallyed sorted in descending magnitude (ie. ![](../fig/3/inline_sortedeigvec.png)).
+Tensors are represented by ellipsoids characterized by calculated eigenvalues (![](../fig/3/inline_eigval.png)) and eigenvectors (![](../fig/3/inline_eigvec.png)) from the previously described matrix. The computed eigenvalues and eigenvectors are normally sorted in descending magnitude (i.e. ![](../fig/3/inline_sortedeigvec.png)).
 
 ![Diffusion tensor](../fig/3/DiffusionTensor.png) {:class="img-responsive"}
 _Adapted from Jelison et al., 2004_
 
-In the following example, we will walk through how to model a diffusion dataset. While there are a number of diffusion models, many of which are implemented in <code>Dipy</code>. However, for the purposes of this lesson, we will focus on the tensor model described above.
+In the following example, we will walk through how to model a diffusion dataset. While there are a number of diffusion models, many of which are implemented in <code>DIPY</code>. However, for the purposes of this lesson, we will focus on the tensor model described above.
 
 
 ### Reconstruction with the `dipy.reconst` module
@@ -45,8 +45,8 @@ The <code>reconst</code> module contains implementations of the following models
 * DSI (Wedeen et al. 2008)
 * DSI with deconvolution (Canales-Rodriguez et al. 2010)
 * Generalized Q Imaging (Yeh et al. 2010)
-* MAPMRI (Ozarsalan et al. 2013)
-* SHORE (Ozarsalan et al. 2008)
+* MAPMRI (Özarslan et al. 2013)
+* SHORE (Özarslan et al. 2008)
 * CSA (Aganj et al. 2009)
 * Q ball (Descoteaux et al. 2007)
 * OPDT (Tristan-Vega et al. 2010)
@@ -55,12 +55,12 @@ The <code>reconst</code> module contains implementations of the following models
 The different algorithms implemented in the module all share a similar conceptual structure:
 
 * <code>ReconstModel</code> objects (e.g., <code>TensorModel</code>) carry the parameters that are required in order to fit a model. For example, the directions and magnitudes of the gradients that were applied in the experiment. The objects all have a <code>fit</code> method, which takes in data, and emites a <code>ReconstFit</code> object. This is where a lot of the heavy lifting of the processing will take place.
-* <code>ReconstFit</code> objects carry the model that was used to generate the object. They also include the parameters that were estimated during fitting of the data. They have methods to caclulate derived statistics, which can differ from model to model. All objects also have an orientation distribution function (<code>odf</code>), and most (but not all) contain a <code>predict</code> method, which enables the prediction of another dataset based on the current gradient table.
+* <code>ReconstFit</code> objects carry the model that was used to generate the object. They also include the parameters that were estimated during fitting of the data. They have methods to calculate derived statistics, which can differ from model to model. All objects also have an orientation distribution function (<code>odf</code>), and most (but not all) contain a <code>predict</code> method, which enables the prediction of another dataset based on the current gradient table.
 
 
 ### Reconstruction with the DTI Model
 
-Let's get started! First, we will need to grab the **preprocessed** dwi files and load them! We will also load in the anatomical image to use as a reference later on.
+Let's get started! First, we will need to grab the **preprocessed** DWI files and load them! We will also load in the anatomical image to use as a reference later on.
 
 ~~~
 from bids.layout import BIDSLayout
@@ -84,21 +84,21 @@ gtab = gradient_table(gt_bvals, gt_bvecs)
 ~~~
 {: .language-python}
 
-Next, we will need to create the tensor model using our gradient table, and then fit the model using our data! We start by creating a mask from our data. We then apply this mask to avoid calculating the tensors in the background of the image! This can be done using dipy's mask module. Then we will fit out data! 
+Next, we will need to create the tensor model using our gradient table, and then fit the model using our data! We start by creating a mask from our data. We then apply this mask to avoid calculating the tensors in the background of the image! This can be done using <code>DIPY</code>'s mask module. Then we will fit out data!
 
 ~~~
 import dipy.reconst.dti as dti
 from dipy.segment.mask import median_otsu
 
-dwi_data = dwi_data.get_data() 
-dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1) 
+dwi_data = dwi_data.get_data()
+dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1)
 
 dti_model = dti.TensorModel(gtab)
 dti_fit = dti_model.fit(dwi_data, mask=dwi_mask)
 ~~~
 {: .language-python}
 
-The fit method creates a <code>TensorFit</code> object which contains the fitting parameters and other attributes of the model. A number of quantitative scalar metrics can be derived from the eigenvalues! In this tutorial, we will cover fractional anisotropy, mean diffusivity, axial diffusivity, and radial diffusivity. Each of these scalar metrics were calculated in the previous fitting step! 
+The fit method creates a <code>TensorFit</code> object which contains the fitting parameters and other attributes of the model. A number of quantitative scalar metrics can be derived from the eigenvalues! In this tutorial, we will cover fractional anisotropy, mean diffusivity, axial diffusivity, and radial diffusivity. Each of these scalar metrics were calculated in the previous fitting step!
 
 
 ### Fractional anisotropy (FA)
@@ -109,9 +109,9 @@ Mathematically, FA is defined as the normalized variance of the eigenvalues of t
 
 ![FA Equation](../fig/3/fa_eqn.png) {:class="img-responsive"}
 
-Values of FA vary between 0 and 1. In the cases of perfect, isotropic diffusion, ![](../fig/3/fa_iso.png), the diffusion tensor is a sphere and FA = 0. As diffusion progressively becomes more anisotropic, eigenvalues become more unequal, causing the tensor to be elongated, with FA approacahing 1. Note that FA should be interpreted carefully. It may be an indication of the density of packing fibers in a voxel and the amount of myelin wrapped around those axons, but it is not always a measure of "tissue integrity". 
+Values of FA vary between 0 and 1. In the cases of perfect, isotropic diffusion, ![](../fig/3/fa_iso.png), the diffusion tensor is a sphere and FA = 0. As diffusion progressively becomes more anisotropic, eigenvalues become more unequal, causing the tensor to be elongated, with FA approaching 1. Note that FA should be interpreted carefully. It may be an indication of the density of packing fibers in a voxel and the amount of myelin wrapped around those axons, but it is not always a measure of "tissue integrity".
 
-Lets take a look at what the FA map looks like! An FA map is a gray-scale image, where higher internsities reflect more anisotropic diffuse regions.
+Let's take a look at what the FA map looks like! An FA map is a gray-scale image, where higher intensities reflect more anisotropic diffuse regions.
 
 _Note: we will have to first create the image from the array, making use of the reference anatomical_
 
@@ -133,12 +133,12 @@ An often used complimentary measure to FA is mean diffusivity (MD). MD is a meas
 
 ![MD Eqn](../fig/3/md_eqn.png) {:class="img-responsive"}
 
-Similar to the previous FA image, let's take a look at what the MD map looks like. Again, higher intensities reflect higher mean diffusivity! 
+Similar to the previous FA image, let's take a look at what the MD map looks like. Again, higher intensities reflect higher mean diffusivity!
 
 ~~~
 md_img = img.new_img_like(ref_niimg=t1_data, data=dti_fit.md)
 plot.plot_anat(md_img)
-~~~ 
+~~~
 {: .language-python}
 
 ![MD Plot](../fig/3/plot_md.png) {:class="img-responsive"}
@@ -146,14 +146,14 @@ plot.plot_anat(md_img)
 
 ### Axial and radial diffusivity (AD & RD)
 
-The final two metrics we will discuss are axial diffusivity (AD) and radial diffusivity (RD). AD describes the diffusion rate along the primary axis of diffusion, along ![](../fig/3/primary_diffusion.png), or parellel to the axon. On the other hand, RD reflects the average diffusivity along the other two minor axes (![](../fig/3/minor_axes.png))
+The final two metrics we will discuss are axial diffusivity (AD) and radial diffusivity (RD). AD describes the diffusion rate along the primary axis of diffusion, along ![](../fig/3/primary_diffusion.png), or parallel to the axon. On the other hand, RD reflects the average diffusivity along the other two minor axes (![](../fig/3/minor_axes.png))
 
 ![Axial and Radial Diffusivities](../fig/3/ax_rad_diff.png) {:class="img-responsive"}
 
 
 ### Tensor visualizations
 
-There are several ways of visualizing tensors. One way is using an RGB map, which overlays the primary diffusion orientation on an FA map. The colours of this map encodes the diffusion orientation. Note that this map provides no directional information (eg. whether the diffusion flows from right-to-left or vice-versa). To do this with <code>dipy</code>, we can use the <code>color_fa</code> function. The colours map to the following orientations:
+There are several ways of visualizing tensors. One way is using an RGB map, which overlays the primary diffusion orientation on an FA map. The colours of this map encodes the diffusion orientation. Note that this map provides no directional information (e.g. whether the diffusion flows from right-to-left or vice-versa). To do this with <code>DIPY</code>, we can use the <code>color_fa</code> function. The colours map to the following orientations:
 
 * Red = Left / Right
 * Green = Anterior / Posterior
@@ -165,7 +165,7 @@ _Note: The plotting functions in <code>nilearn</code> are unable to visualize th
 from dipy.reconst.dti import color_fa
 RGB_map = color_fa(dti_fit.fa, dti_fit.evecs)
 
-from scipy import ndimage 
+from scipy import ndimage
 
 fig, ax = plt.subplots(1,3, figsize=(10,10))
 ax[0].imshow(ndimage.rotate(RGB_map[:, RGB_map.shape[1]//2, :, :], 90, reshape=False))
@@ -176,20 +176,20 @@ ax[2].imshow(ndimage.rotate(RGB_map[:, :, RGB_map.shape[2]//2, :], 90, reshape=F
 
 ![RGB FA Map](../fig/3/plot_fa_rgb.png) {:class="img-responsive"}
 
-Another way of visualizing the tensors is to display the diffusion tensor in each imaging voxel with colour encoding (Please refer to the [<code>dipy</code> documentation](https://dipy.org/tutorials/) for the necessary steps to perform this type of visualization, as it can be memory intensive). Below is an example of one such tensor visualization.
+Another way of visualizing the tensors is to display the diffusion tensor in each imaging voxel with colour encoding (Please refer to the [<code>DIPY</code> documentation](https://dipy.org/tutorials/) for the necessary steps to perform this type of visualization, as it can be memory intensive). Below is an example of one such tensor visualization.
 
 ![Tensor Visualization](../fig/3/TensorViz.png) {:class="img-responsive"}
 
 
 ### Some notes on DTI
 
-DTI is only one of many models and is one of the simplest models available for modelling diffusion. While it is used for many studies, there are also some drawbacks (eg. ability to distinguish multiple fibre orientations in an imaging voxel). Examples of this can be seen below!
+DTI is only one of many models and is one of the simplest models available for modelling diffusion. While it is used for many studies, there are also some drawbacks (e.g. ability to distinguish multiple fibre orientations in an imaging voxel). Examples of this can be seen below!
 
 ![DTI Drawbacks](../fig/3/FiberConfigurations.png) {:class="img-responsive"}
 
 _Sourced from Sotiropolous and Zalewsky (2017). Building connectomes using diffusion MRI: why, how, and but. NMR in Biomedicine. 4(32). e3752. doi:10.1002/nbm.3752._
 
-Though other models are outside the scope of this lesson, we recommend looking into some of the pros and cons of each model (listed previously) to choose one best suited for your data! 
+Though other models are outside the scope of this lesson, we recommend looking into some of the pros and cons of each model (listed previously) to choose one best suited for your data!
 
 > ## Exercise 1
 > 1. Plot the axial and radial diffusivity maps of the example given. Start from fitting the preprocessed diffusion image.
@@ -202,9 +202,9 @@ Though other models are outside the scope of this lesson, we recommend looking i
 >> from dipy.segment.mask import median_otsu
 >> from nilearn import image as img
 >> import nibabel as nib
->> 
+>>
 >> layout = BIDSLayout("../data/ds000030/derivatives", validate=False)
->> 
+>>
 >> t1 = layout.get(subject='10788', suffix='T1w', extension='nii.gz', return_type='file')[0]
 >> dwi = layout.get(subject='10788', suffix='preproc', extension='nii.gz', return_type='file')[0]
 >> bval = layout.get(subject='10788', suffix='preproc', extension='bval', return_type='file')[0]
@@ -215,8 +215,8 @@ Though other models are outside the scope of this lesson, we recommend looking i
 >>
 >> gt_bvals, gt_bvecs = read_bvals_bvecs(bval, bvec)
 >> gtab = gradient_table(gt_bvals, gt_bvecs)
->> 
->> dwi_data = dwi_data.get_data() 
+>>
+>> dwi_data = dwi_data.get_data()
 >> dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1)
 >>
 >> # Fit dti model
@@ -226,7 +226,7 @@ Though other models are outside the scope of this lesson, we recommend looking i
 >> # Plot axial diffusivity map
 >> ad_img = img.new_img_like(ref_niimg=t1_data, data=dti_fit.ad)
 >> plot.plot_anat(ad_img)
->> 
+>>
 >> # Plot radial diffusivity map
 >> rd_img = img.new_img_like(ref_niimg=t1_data, data=dti_fit.rd)
 >> plot.plot_anat(rd_img)


### PR DESCRIPTION
Fix spelling and capitalize acronyms in lesson 03.

Remove trailing whitespaces.