### PR TITLE
ENH: Add `osfclient` to the requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ dipy==1.3.0
 fury==0.6.1
 matplotlib
 nilearn==0.7.0
+osfclient==0.0.4
 pybids==0.12.4


### PR DESCRIPTION
Add `osfclient` to the requirements list to be able to download the necessary
data automatically.