### PR TITLE
DOC: Add terms to glossary

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -4,6 +4,77 @@ layout: reference
 
 ## Glossary
 
-FIXME
+~~~
+{:auto_ids}
+AD
+:   Axial Diffusivity
+
+BIDS
+:   Brain Imaging Data Structure
+
+CSA
+:   Constant Solid Angle
+
+CSD
+:   Constrained Spherical Deconvolution
+
+dMRI
+:   diffusion Magnetic Resonance Imaging
+
+DKI
+:   Diffusion Kurtosis Imaging
+
+DSI
+:   Diffusion Spectrum Imaging
+
+DTI
+:   Diffusion Tensor Imaging
+
+DWI
+:   Diffusion-Weighted Imaging
+
+EPI
+:   Echo Planar Imaging
+
+fODF
+:   fiber Orientation Distribution Function
+
+FA
+:   Fractional Anisotropy
+
+FOD
+:   Fiber Orientation Distribution
+
+FRF
+:   Fiber Response Function
+
+GFA
+:   Generalized Fractional Anisotropy
+
+MAPMRI
+:   Mean Apparent Propagator MRI
+
+MD
+:   Mean Diffusivity
+
+ODF
+:   Orientation Distribution Function
+
+PMF
+:   Probability Mass Function
+
+RD
+:   Radial Diffusivity
+
+SD
+:   Spherical Deconvolution
+
+SH
+:   Spherical Harmonics
+
+SHORE
+:   Simple Harmonic Oscillator Based Reconstruction and Estimation
+~~~
+{: .source}
 
 {% include links.md %}


### PR DESCRIPTION
Add terms to glossary.

Adds the Carpentries [glossary component](https://carpentries.github.io/lesson-example/03-organization/index.html) as described [here](https://carpentries.github.io/lesson-example/reference.html) and resolves #44.