### PR TITLE
ENH: Remove unnecessary content from the CSD episode

### DIFF
--- a/_episodes/05-constrained_spherical_deconvolution.md
+++ b/_episodes/05-constrained_spherical_deconvolution.md
@@ -41,28 +41,45 @@ so-called Spherical Harmonics (SH) which are a basis that allow to represent
 any function on the sphere (much like the Fourier analysis allows to represent
 a function in terms of in terms of trigonometric functions).
 
-In this lesson we will be using the Constrained Spherical Deconvolution (CSD)
+In this episode we will be using the Constrained Spherical Deconvolution (CSD)
 method proposed by Tournier *et al*. in 2007. In essence, CSD imposes a
 non-negativity constraint in the reconstructed fODF. For the sake of
-simplicity, single-shell data will be used in this lesson.
+simplicity, single-shell data will be used in this episode.
 
 Let's start by loading the necessary data. For simplicity, we will assume that
 the gradient table is the same across all voxels after the pre-processing.
 
 ~~~
+import os
+
 import nibabel as nib
 import numpy as np
 
+from bids.layout import BIDSLayout
+
 from dipy.core.gradients import gradient_table
-from dipy.data import get_fnames, default_sphere
+from dipy.data import default_sphere
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.io.image import load_nifti
 
-hardi_fname, hardi_bval_fname, hardi_bvec_fname = get_fnames('stanford_hardi')
 
-data, affine = load_nifti(hardi_fname)
+dwi_layout = BIDSLayout('../../data/ds000221/derivatives/uncorrected_topup_eddy/', validate=False)
+t1_layout = BIDSLayout('../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/', validate=False)
+gradient_layout = BIDSLayout('../../data/ds000221/sub-010006/ses-01/dwi/', validate=False)
 
-bvals, bvecs = read_bvals_bvecs(hardi_bval_fname, hardi_bvec_fname)
+subj = '010006'
+
+# Get the diffusion files
+dwi_fname = dwi_layout.get(subject=subj, suffix='dwi', extension='nii.gz', return_type='file')[0]
+bval_fname = gradient_layout.get(subject=subj, suffix='dwi', extension='bval', return_type='file')[0]
+bvec_fname = gradient_layout.get(subject=subj, suffix='dwi', extension='bvec', return_type='file')[0]
+
+# Get the anatomical file
+t1w_fname = t1_layout.get(subject=subj, extension='nii.gz', return_type='file')[0]
+
+data, affine = load_nifti(dwi_fname)
+
+bvals, bvecs = read_bvals_bvecs(bval_fname, bvec_fname)
 gtab = gradient_table(bvals, bvecs)
 ~~~
 {: .language-python}
@@ -73,7 +90,7 @@ we can proceed with the two steps of CSD.
 
 ## Step 1. Estimation of the fiber response function.
 
-In this lesson the response function will be estimated from a local brain
+In this episode the response function will be estimated from a local brain
 region known to belong to the white matter and where it is known that there are
 single coherent fiber populations. This is determined by checking the
 Fractional Anisotropy (FA) derived from the DTI model.
@@ -301,6 +318,7 @@ plt.show()
 {: .language-python}
 
 ![csd_peaks_fodfs](../fig/5/csd_peaks_fodfs.png){:class="img-responsive"} \
+CSD Peaks and ODFs.
 
 
 

--- a/code/05-constrained_spherical_deconvolution/05-constrained_spherical_deconvolution.ipynb
+++ b/code/05-constrained_spherical_deconvolution/05-constrained_spherical_deconvolution.ipynb
@@ -1,6 +1,47 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constrained Spherical Deconvolution (CSD)\n",
+    "\n",
+    "Spherical Deconvolution (SD) is a set of methods to reconstruct the local fiber\n",
+    "Orientation Distribution Functions (fODF) from diffusion MRI data. They have\n",
+    "become a popular choice for recovering the fiber orientation due to their\n",
+    "ability to resolve fiber crossings with small inter-fiber angles in datasets\n",
+    "acquired within a clinically feasible scan time. SD methods are based on the\n",
+    "assumption that the acquired diffusion signal in each voxel can be modeled as a\n",
+    "spherical convolution between the fODF and the fiber response function (FRF)\n",
+    "that describes the common signal profile from the white matter (WM) bundles\n",
+    "contained in the voxel. Thus, if the FRF can be estimated, the fODF can be\n",
+    "recovered as a deconvolution problem by solving a system of linear equations.\n",
+    "These methods can work on both single-shell and multi-shell data.\n",
+    "\n",
+    "The basic equations of an SD method can summarized as\n",
+    "![spherical_deconvolution_equation](../fig/1/spherical_deconvolution_equation.png){:class=\"img-responsive\"} \\\n",
+    "Spherical deconvolution\n",
+    "\n",
+    "There are a number of variants to the general SD framework that differ, among\n",
+    "others, in the minimization objective and the regularization penalty imposed to\n",
+    "obtain some desirable properties in the linear equation framework.\n",
+    "\n",
+    "In order to perform the deconvolution over the sphere, the spherical\n",
+    "representation of the diffusion data has to be obtained. This is done using the\n",
+    "so-called Spherical Harmonics (SH) which are a basis that allow to represent any\n",
+    "function on the sphere (much like the Fourier analysis allows to represent a\n",
+    "function in terms of in terms of trigonometric functions).\n",
+    "\n",
+    "In this episode we will be using the Constrained Spherical Deconvolution (CSD)\n",
+    "method proposed by Tournier *et al*. in 2007. In essence, CSD imposes a\n",
+    "non-negativity constraint in the reconstructed fODF. For the sake of simplicity,\n",
+    "single-shell data will be used in this episode.\n",
+    "\n",
+    "Let's start by loading the necessary data. For simplicity, we will assume that\n",
+    "the gradient table is the same across all voxels after the pre-processing."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -43,72 +84,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "title: \"Constrained Spherical Deconvolution (CSD)\"\n",
-    "teaching: 30\n",
-    "exercises: 5\n",
-    "questions:\n",
-    "- \"What is Constrained Spherical Deconvolution (CSD)?\"\n",
-    "- \"What does CSD offer compared to DTI?\"\n",
-    "objectives:\n",
-    "- \"Understand Spherical Deconvolution\"\n",
-    "- \"Visualizing the fiber Orientation Distribution Function\"\n",
-    "keypoints:\n",
-    "- \"CSD uses the information along more gradient encoding directions\"\n",
-    "- \"It allows to resolve complex fiber configurations, such as crossings\"\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Constrained Spherical Deconvolution (CSD)\n",
-    "\n",
-    "Spherical Deconvolution (SD) is a set of methods to reconstruct the local fiber\n",
-    "Orientation Distribution Functions (fODF) from diffusion MRI data. They have\n",
-    "become a popular choice for recovering the fiber orientation due to their\n",
-    "ability to resolve fiber crossings with small inter-fiber angles in datasets\n",
-    "acquired within a clinically feasible scan time. SD methods are based on the\n",
-    "assumption that the acquired diffusion signal in each voxel can be modeled as a\n",
-    "spherical convolution between the fODF and the fiber response function (FRF)\n",
-    "that describes the common signal profile from the white matter (WM) bundles\n",
-    "contained in the voxel. Thus, if the FRF can be estimated, the fODF can be\n",
-    "recovered as a deconvolution problem by solving a system of linear equations.\n",
-    "These methods can work on both single-shell and multi-shell data.\n",
-    "\n",
-    "The basic equations of an SD method can summarized as\n",
-    "![spherical_deconvolution_equation](../fig/1/spherical_deconvolution_equation.png){:class=\"img-responsive\"} \\\n",
-    "Spherical deconvolution\n",
-    "\n",
-    "There are a number of variants to the general SD framework that differ, among\n",
-    "others, in the minimization objective and the regularization penalty imposed to\n",
-    "obtain some desirable properties in the linear equation framework.\n",
-    "\n",
-    "In order to perform the deconvolution over the sphere, the spherical\n",
-    "representation of the diffusion data has to be obtained. This is done using the\n",
-    "so-called Spherical Harmonics (SH) which are a basis that allow to represent any\n",
-    "function on the sphere (much like the Fourier analysis allows to represent a\n",
-    "function in terms of in terms of trigonometric functions).\n",
-    "\n",
-    "In this lesson we will be using the Constrained Spherical Deconvolution (CSD)\n",
-    "method proposed by Tournier *et al*. in 2007. In essence, CSD imposes a\n",
-    "non-negativity constraint in the reconstructed fODF. For the sake of simplicity,\n",
-    "single-shell data will be used in this lesson.\n",
-    "\n",
-    "Let's start by loading the necessary data. For simplicity, we will assume that\n",
-    "the gradient table is the same across all voxels after the pre-processing."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "{: .language-python}\n",
-    "\n",
     "You can verify the b-values of the dataset by looking at the attribute\n",
     "``gtab.bvals``. Now that a datasets with multiple gradient directions is\n",
     "loaded, we can proceed with the two steps of CSD.\n",
     "\n",
     "## Step 1. Estimation of the fiber response function.\n",
     "\n",
-    "In this lesson the response function will be estimated from a local brain region\n",
+    "In this episode the response function will be estimated from a local brain region\n",
     "known to belong to the white matter and where it is known that there are single\n",
     "coherent fiber populations. This is determined by checking the Fractional\n",
     "Anisotropy (FA) derived from the DTI model.\n",
@@ -144,8 +126,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
     "The `response` tuple contains two elements. The first is an array with\n",
     "the eigenvalues of the response function and the second is the average `S0`\n",
     "signal value for this response.\n",
@@ -165,13 +145,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "{: .language-python}"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -184,8 +157,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .output}\n",
-    "\n",
     "The tensor generated belonging to the response function must be prolate (two\n",
     "smaller eigenvalues should be equal), and look anisotropic with a ratio of\n",
     "second to first eigenvalue of about 0.2. Or in other words, the axial\n",
@@ -204,13 +175,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "{: .language-python}"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -223,8 +187,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .output}\n",
-    "\n",
     "It is good practice to visualize the response function's ODF, which also gives\n",
     "an insightful idea around the SD framework. The response function's ODF should\n",
     "have sharp lobes, as the anisotropy of its diffusivity indicates:"
@@ -266,8 +228,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
     "![frf](../fig/1/frf.png){:class=\"img-responsive\"} \\\n",
     "Estimated response function"
    ]
@@ -285,9 +245,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
-    "\n",
     "Note that, although fast, the FA threshold might not always be the best way to\n",
     "find the response function, since it depends on the diffusion tensor, which has\n",
     "a number of limitations. Similarly, different bundles are known to have\n",
@@ -331,8 +288,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
     "For illustration purposes we will fit only a small portion of the data."
    ]
   },
@@ -355,8 +310,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
     "Getting the fODFs from the model fit is straightforward in `DIPY`. As a side\n",
     "note, it is worthwhile mentioning that the orientation distribution recovered\n",
     "by SD methods is also named fODFs to distinguish from the diffusion ODFs (dODFs)\n",
@@ -378,8 +331,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
     "Here we visualize only a 30x30 region (i.e. the slice corresponding to the `[20:50, 55:85, 38:39]` volume data region that was used in the tutorial)."
    ]
   },
@@ -411,9 +362,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
-    "\n",
     "![csd_odfs](../fig/1/csd_odfs.png){:class=\"img-responsive\"} \\\n",
     "CSD ODFs.\n",
     "\n",
@@ -462,8 +410,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
     "![csd_peaks](../fig/1/csd_peaks.png){:class=\"img-responsive\"} \\\n",
     "CSD Peaks.\n",
     "\n",
@@ -493,8 +439,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "{: .language-python}\n",
-    "\n",
     "![csd_peaks_fodfs](../fig/1/csd_peaks_fodfs.png){:class=\"img-responsive\"} \\\n",
     "\n",
     "\n",


### PR DESCRIPTION
Remove unnecessary content from the CSD episode:
- Use the lesson data.
- Remove the `{: .language-python}` episode Markdown-specific markup from the
  Jupyter notebook.
- Remove the episode Markdown-specific header from the Jupyter notebook.
- Move the data fetching code cell to the appropriate place in the Jupyter
  notebook.

Take advantage of the commit to:
- Use the term "episode" to refer to the section.
- Add a caption to the last figure.