### PR TITLE
Manual episode order for Figures

### DIFF
--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -3,11 +3,17 @@ title: Figures
 ---
 
 {% include base_path.html %}
+{% include manual_episode_order.html %}
 
 <script>
   window.onload = function() {
     var lesson_episodes = [
-    {% for episode in site.episodes %}
+    {% for lesson_episode in lesson_episodes %}
+      {% if site.episode_order %}
+        {% assign episode = site.episodes | where: "slug", lesson_episode | first %}
+      {% else %}
+        {% assign episode = lesson_episode %}
+      {% endif %}
     "{{ episode.url }}"{% unless forloop.last %},{% endunless %}
     {% endfor %}
     ];
@@ -58,10 +64,15 @@ title: Figures
     }
   }
 </script>
-{% comment %}
-Create anchor for each one of the episodes.
-{% endcomment %}
-{% for episode in site.episodes %}
+
+{% comment %} Create anchor for each one of the episodes.  {% endcomment %}
+
+{% for lesson_episode in lesson_episodes %}
+  {% if site.episode_order %}
+    {% assign episode = site.episodes | where: "slug", lesson_episode | first %}
+  {% else %}
+    {% assign episode = lesson_episode %}
+  {% endif %}
 <article id="{{ episode.url }}" class="figures"></article>
 {% endfor %}
 


### PR DESCRIPTION
This repository had an older version of `_extras/figures.md`, which pre-dates the introduction of manual episode ordering for lessons. This PR brings that file up-to-date with the most recent version of the file, and should cause your Figures page to respect the order of episodes in the lesson.