### PR TITLE
STYLE: Prefer `{{ relative_root_path }}` to resolve figure paths

### DIFF
--- a/_episodes/constrained_spherical_deconvolution.md
+++ b/_episodes/constrained_spherical_deconvolution.md
@@ -28,7 +28,7 @@ recovered as a deconvolution problem by solving a system of linear equations.
 These methods can work on both single-shell and multi-shell data.
 
 The basic equations of an SD method can be summarized as
-![Spherical deconvolution equation](../fig/constrained_spherical_deconvolution/spherical_deconvolution_equation.png){:class="img-responsive"} \
+![Spherical deconvolution equation]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/spherical_deconvolution_equation.png){:class="img-responsive"} \
 Spherical deconvolution
 
 There are a number of variants to the general SD framework that differ, among
@@ -185,7 +185,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![Fiber Response Function (FRF)](../fig/constrained_spherical_deconvolution/frf.png){:class="img-responsive"} \
+![Fiber Response Function (FRF)]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/frf.png){:class="img-responsive"} \
 Estimated response function
 
 
@@ -295,8 +295,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-
-![CSD ODFs](../fig/constrained_spherical_deconvolution/csd_odfs.png){:class="img-responsive"} \
+![CSD ODFs]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_odfs.png){:class="img-responsive"} \
 CSD ODFs.
 
 The peak directions (maxima) of the fODFs can be found from the fODFs. For this
@@ -357,7 +356,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![CSD peaks](../fig/constrained_spherical_deconvolution/csd_peaks.png){:class="img-responsive"} \
+![CSD peaks]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_peaks.png){:class="img-responsive"} \
 CSD Peaks.
 
 We can finally visualize both the fODFs and peaks in the same space.
@@ -404,7 +403,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![CSD peaks and fODFs](../fig/constrained_spherical_deconvolution/csd_peaks_fodfs.png){:class="img-responsive"} \
+![CSD peaks and fODFs]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_peaks_fodfs.png){:class="img-responsive"} \
 CSD Peaks and ODFs.
 
 

--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -19,17 +19,17 @@ Diffusion tensor imaging or "DTI" refers to images describing diffusion with a t
 
 The tensor models the diffusion signal mathematically as:
 
-![Diffusion signal equation](../fig/diffusion_tensor_imaging/diffusion_eqn.png) {:class="img-responsive"}
+![Diffusion signal equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/diffusion_eqn.png) {:class="img-responsive"}
 
-Where ![Diffusion unit vector](../fig/diffusion_tensor_imaging/inline_unitvector.png) is a unit vector in 3D space indicating the direction of measurement and b are the parameters of the measurement, such as the strength and duration of diffusion-weighting gradient. ![Diffusion signal](../fig/diffusion_tensor_imaging/inline_diffusionsignal.png) is the diffusion-weighted signal measured and ![Non-weighted diffusion signal](../fig/diffusion_tensor_imaging/inline_nondiffsignal.png) is the signal conducted in a measurement with no diffusion weighting. ![Diffusivity](../fig/diffusion_tensor_imaging/inline_diffusionmatrix.png) is a positive-definite quadratic form, which contains six free parameters to be fit. These six parameters are:
+Where ![Diffusion unit vector]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_unitvector.png) is a unit vector in 3D space indicating the direction of measurement and b are the parameters of the measurement, such as the strength and duration of diffusion-weighting gradient. ![Diffusion signal]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_diffusionsignal.png) is the diffusion-weighted signal measured and ![Non-weighted diffusion signal]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_nondiffsignal.png) is the signal conducted in a measurement with no diffusion weighting. ![Diffusivity]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_diffusionmatrix.png) is a positive-definite quadratic form, which contains six free parameters to be fit. These six parameters are:
 
-![Diffusivity matrix](../fig/diffusion_tensor_imaging/diffusion_matrix.png) {:class="img-responsive"}
+![Diffusivity matrix]({{ relative_root_path }}/fig/diffusion_tensor_imaging/diffusion_matrix.png) {:class="img-responsive"}
 
-The diffusion matrix is a variance-covariance matrix of the diffusivity along the three spatial dimensions. Note that we can assume that the diffusivity has antipodal symmetry, so elements across the diagonal of the matrix are equal. For example: ![Symmetry in the diffusivity matrix](../fig/diffusion_tensor_imaging/inline_diagelements.png). This is why there are only 6 free parameters to estimate here.
+The diffusion matrix is a variance-covariance matrix of the diffusivity along the three spatial dimensions. Note that we can assume that the diffusivity has antipodal symmetry, so elements across the diagonal of the matrix are equal. For example: ![Symmetry in the diffusivity matrix]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_diagelements.png). This is why there are only 6 free parameters to estimate here.
 
-Tensors are represented by ellipsoids characterized by calculated eigenvalues (![Diffusivity matrix eigenvalues](../fig/diffusion_tensor_imaging/inline_eigval.png)) and eigenvectors (![Diffusivity matrix eigenvectors](../fig/diffusion_tensor_imaging/inline_eigvec.png)) from the previously described matrix. The computed eigenvalues and eigenvectors are normally sorted in descending magnitude (i.e. ![Diffusivity matrix eigenvalues magnitudes](../fig/diffusion_tensor_imaging/inline_sortedeigvec.png)). Eigenvalues are always strictly positive in the context of dMRI and are measured in mm^2/s. In the DTI model, the largest eigenvalue gives the principal direction of the diffusion tensor, and the other two eigenvectors span the orthogonal plane to the former direction.
+Tensors are represented by ellipsoids characterized by calculated eigenvalues (![Diffusivity matrix eigenvalues]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_eigval.png)) and eigenvectors (![Diffusivity matrix eigenvectors]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_eigvec.png)) from the previously described matrix. The computed eigenvalues and eigenvectors are normally sorted in descending magnitude (i.e. ![Diffusivity matrix eigenvalues magnitudes]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_sortedeigvec.png)). Eigenvalues are always strictly positive in the context of dMRI and are measured in mm^2/s. In the DTI model, the largest eigenvalue gives the principal direction of the diffusion tensor, and the other two eigenvectors span the orthogonal plane to the former direction.
 
-![Diffusion tensor](../fig/diffusion_tensor_imaging/DiffusionTensor.png) {:class="img-responsive"}
+![Diffusion tensor]({{ relative_root_path }}/fig/diffusion_tensor_imaging/DiffusionTensor.png) {:class="img-responsive"}
 _Adapted from Jelison et al., 2004_
 
 In the following example, we will walk through how to model a diffusion dataset. While there are a number of diffusion models, many of which are implemented in <code>DIPY</code>. However, for the purposes of this lesson, we will focus on the tensor model described above.
@@ -111,9 +111,9 @@ Fractional anisotropy (FA) characterizes the degree to which the distribution of
 
 Mathematically, FA is defined as the normalized variance of the eigenvalues of the tensor:
 
-![FA equation](../fig/diffusion_tensor_imaging/fa_eqn.png) {:class="img-responsive"}
+![FA equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/fa_eqn.png) {:class="img-responsive"}
 
-Values of FA vary between 0 and 1 (unitless). In the cases of perfect, isotropic diffusion, ![Isotropic diffusion eigenvalues](../fig/diffusion_tensor_imaging/fa_iso.png), the diffusion tensor is a sphere and FA = 0.  If the first two eigenvalues are equal the tensor will be oblate or planar, whereas if the first eigenvalue is larger than the other two, it will have the mentioned ellipsoid shape: as diffusion progressively becomes more anisotropic, eigenvalues become more unequal, causing the tensor to be elongated, with FA approaching 1. Note that FA should be interpreted carefully. It may be an indication of the density of packing fibers in a voxel and the amount of myelin wrapped around those axons, but it is not always a measure of "tissue integrity".
+Values of FA vary between 0 and 1 (unitless). In the cases of perfect, isotropic diffusion, ![Isotropic diffusion eigenvalues]({{ relative_root_path }}/fig/diffusion_tensor_imaging/fa_iso.png), the diffusion tensor is a sphere and FA = 0.  If the first two eigenvalues are equal the tensor will be oblate or planar, whereas if the first eigenvalue is larger than the other two, it will have the mentioned ellipsoid shape: as diffusion progressively becomes more anisotropic, eigenvalues become more unequal, causing the tensor to be elongated, with FA approaching 1. Note that FA should be interpreted carefully. It may be an indication of the density of packing fibers in a voxel and the amount of myelin wrapped around those axons, but it is not always a measure of "tissue integrity".
 
 Let's take a look at what the FA map looks like! An FA map is a gray-scale image, where higher intensities reflect more anisotropic diffuse regions.
 
@@ -128,7 +128,7 @@ plot.plot_anat(fa_img)
 ~~~
 {: .language-python}
 
-![FA plot](../fig/diffusion_tensor_imaging/plot_fa.png) {:class="img-responsive"}
+![FA plot]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_fa.png) {:class="img-responsive"}
 
 Derived from partial volume effects in imaging voxels due to the presence of different tissues, noise in the measurements and numerical errors, the DTI model estimation may yield negative eigenvalues. Such *degenerate* case is not physically meaningful. These values are usually revealed as black or 0-valued pixels in FA maps.
 
@@ -138,7 +138,7 @@ FA is a central value in dMRI: large FA values imply that the underlying fiber p
 
 An often used complimentary measure to FA is mean diffusivity (MD). MD is a measure of the degree of diffusion, independent of direction. This is sometimes known as the apparent diffusion coefficient (ADC). Mathematically, MD is computed as the mean eigenvalues of the tensor and is measured in mm^2/s.
 
-![MD equation](../fig/diffusion_tensor_imaging/md_eqn.png) {:class="img-responsive"}
+![MD equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/md_eqn.png) {:class="img-responsive"}
 
 Similar to the previous FA image, let's take a look at what the MD map looks like. Again, higher intensities reflect higher mean diffusivity!
 
@@ -149,14 +149,14 @@ plot.plot_anat(md_img, cut_coords=(0, -29, 20), vmin=0, vmax=0.01)
 ~~~
 {: .language-python}
 
-![MD plot](../fig/diffusion_tensor_imaging/plot_md.png) {:class="img-responsive"}
+![MD plot]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_md.png) {:class="img-responsive"}
 
 
 ### Axial and radial diffusivity (AD & RD)
 
-The final two metrics we will discuss are axial diffusivity (AD) and radial diffusivity (RD). Two tensors with different shapes may yield the same FA values, and additional measures such as AD and RD are required to further characterize the tensor. AD describes the diffusion rate along the primary axis of diffusion, along ![Axial diffusivity eigenvalue](../fig/diffusion_tensor_imaging/primary_diffusion.png), or parallel to the axon (and hence, some works refer to it as the *parallel diffusivity*). On the other hand, RD reflects the average diffusivity along the other two minor axes (being named as *perpendicular diffusivity* in some works) (![Radial diffusivity eigenvalue](../fig/diffusion_tensor_imaging/minor_axes.png)). Both are measured in mm^2/s.
+The final two metrics we will discuss are axial diffusivity (AD) and radial diffusivity (RD). Two tensors with different shapes may yield the same FA values, and additional measures such as AD and RD are required to further characterize the tensor. AD describes the diffusion rate along the primary axis of diffusion, along ![Axial diffusivity eigenvalue]({{ relative_root_path }}/fig/diffusion_tensor_imaging/primary_diffusion.png), or parallel to the axon (and hence, some works refer to it as the *parallel diffusivity*). On the other hand, RD reflects the average diffusivity along the other two minor axes (being named as *perpendicular diffusivity* in some works) (![Radial diffusivity eigenvalues]({{ relative_root_path }}/fig/diffusion_tensor_imaging/minor_axes.png)). Both are measured in mm^2/s.
 
-![Axial and radial diffusivities](../fig/diffusion_tensor_imaging/ax_rad_diff.png) {:class="img-responsive"}
+![Axial and radial diffusivities]({{ relative_root_path }}/fig/diffusion_tensor_imaging/ax_rad_diff.png) {:class="img-responsive"}
 
 
 ### Tensor visualizations
@@ -183,18 +183,18 @@ ax[2].imshow(ndimage.rotate(RGB_map[:, :, RGB_map.shape[2]//2, :], 90, reshape=F
 ~~~
 {: .language-python}
 
-![RGB FA map](../fig/diffusion_tensor_imaging/plot_fa_rgb.png) {:class="img-responsive"}
+![RGB FA map]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_fa_rgb.png) {:class="img-responsive"}
 
 Another way of visualizing the tensors is to display the diffusion tensor in each imaging voxel with colour encoding (Please refer to the [<code>DIPY</code> documentation](https://dipy.org/tutorials/) for the necessary steps to perform this type of visualization, as it can be memory intensive). Below is an example of one such tensor visualization.
 
-![Tensor visualization](../fig/diffusion_tensor_imaging/TensorViz.png) {:class="img-responsive"}
+![Tensor visualization]({{ relative_root_path }}/fig/diffusion_tensor_imaging/TensorViz.png) {:class="img-responsive"}
 
 
 ### Some notes on DTI
 
 DTI is only one of many models and is one of the simplest models available for modelling diffusion. While it is used for many studies, there are also some drawbacks (e.g. ability to distinguish multiple fibre orientations in an imaging voxel). Examples of this can be seen below!
 
-![DTI drawbacks](../fig/diffusion_tensor_imaging/FiberConfigurations.png) {:class="img-responsive"}
+![DTI drawbacks]({{ relative_root_path }}/fig/diffusion_tensor_imaging/FiberConfigurations.png) {:class="img-responsive"}
 
 _Sourced from Sotiropoulos and Zalesky (2017). Building connectomes using diffusion MRI: why, how, and but. NMR in Biomedicine. 4(32). e3752. doi:10.1002/nbm.3752._
 

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -18,7 +18,7 @@ start: true
 
 Diffusion imaging probes the random, microscopic motion of water protons by employing MRI sequences which are sensitive to the geometry and environmental organization surrounding the water protons. This is a popular technique for studying the white matter of the brain. The diffusion within biological structures, such as the brain, are often restricted due to barriers (eg. cell membranes), resulting in a preferred direction of diffusion (anisotropy). A typical diffusion MRI scan will acquire multiple volumes that are sensitive to a particular diffusion direction and result in diffusion-weighted images (DWI). Diffusion that exhibits directionality in the same direction result in an attenuated signal. With further processing (to be discussed later in the lesson), the acquired images can provide measurements which are related to the microscopic changes and estimate white matter trajectories. Images with no diffusion weighting are also acquired as part of the acquisition protocol.
 
-![Diffusion along X, Y, and Z directions](../fig/introduction/DiffusionDirections.png){:class="img-responsive"} \
+![Diffusion along X, Y, and Z directions]({{ relative_root_path }}/fig/introduction/DiffusionDirections.png){:class="img-responsive"} \
 Diffusion along X, Y, and Z directions
 
 ## b-values & b-vectors
@@ -195,7 +195,7 @@ for i, slice in enumerate(slices):
 ~~~
 {: .language-python}
 
-![DWI slice](../fig/introduction/dwi_slice.png){:class="img-responsive"}
+![DWI slice]({{ relative_root_path }}/fig/introduction/dwi_slice.png){:class="img-responsive"}
 
 We can also see how the diffusion gradients are represented. This is plotted on a sphere, the further away from the center of the sphere, the stronger the diffusion gradient (increased sensitivity to diffusion).
 
@@ -208,7 +208,7 @@ ax.scatter(bvec_txt[0], bvec_txt[1], bvec_txt[2])
 ~~~
 {: .language-python}
 
-![Diffusion gradient sphere](../fig/introduction/diffusion_gradient.png){:class="img-responsive"}
+![Diffusion gradient sphere]({{ relative_root_path }}/fig/introduction/diffusion_gradient.png){:class="img-responsive"}
 
 The files associated with the diffusion gradients need to converted to a <code>GradientTable</code> object to be used with <code>Dipy</code>. A <code>GradientTable</code> object can be implemented using the <code>dipy.core.gradients</code> module. The input to the <code>GradientTable</code> should be our the values for our gradient directions and amplitudes we read in.
 

--- a/_episodes/local_tractography.md
+++ b/_episodes/local_tractography.md
@@ -23,7 +23,7 @@ Streamline propagation is, in essence, a numerical analysis integration
 problem. The problem lies in finding a curve that joins a set of discrete local
 directions. As such, it takes the form of a differential equation problem of
 the form:
-![Streamline propagation equation](../fig/local_tractography/streamline_propagation_diff_equation.png){:class="img-responsive"} \
+![Streamline propagation equation]({{ relative_root_path }}/fig/local_tractography/streamline_propagation_diff_equation.png){:class="img-responsive"} \
 Streamline propagation differential equation
 
 where the curve $r(s)$ needs to be solved for.

--- a/_episodes/preprocessing.md
+++ b/_episodes/preprocessing.md
@@ -18,7 +18,7 @@ start: true
 Diffusion preprocessing typically comprises of a series of steps, which may vary depending on how the data is acquired. Some consensus has been reached for certain preprocessing steps, while others are still up for debate. The lesson will primarily focus on the preprocessing steps where consensus has been reached. Preprocessing is performed using a few well-known software packages (e.g. FSL, ANTs). For the purposes of these lessons, preprocessing steps requiring these software packages has already been performed for the dataset <code>ds000221</code> and the commands required for each step will be provided. This dataset contains single shell diffusion data with 7 b=0 s/mm^2 volumes (non-diffusion weighted) and 60 b=1000 s/mm^2 volumes. In addition, field maps (found in the <code>fmap</code> directory are acquired with opposite phase-encoding directions).
 
 To illustrate what the preprocessing step may look like, here is an example preprocessing workflow from QSIPrep (Cieslak _et al_, 2020):
-![Preprocessing steps](../fig/preprocessing/preprocess_steps.jpg)
+![Preprocessing steps]({{ relative_root_path }}/fig/preprocessing/preprocess_steps.jpg)
 
 dMRI has some similar challenges to fMRI preprocessing, as well as some unique [ones](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3366862/).
 
@@ -78,7 +78,7 @@ nib.save(img, os.path.join(out_dir, "sub-%s_ses-01_brainmask.nii.gz" % subj))
 ~~~
 {: .language-python}
 
-![b0 brain mask](../fig/preprocessing/dwi_brainmask.png)
+![b0 brain mask]]({{ relative_root_path }}/fig/preprocessing/dwi_brainmask.png)
 
 ### FSL [<code>topup</code>](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/topup)
 
@@ -134,7 +134,7 @@ applytopup --imain=../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_d
 ~~~
 {: .language-bash}
 
-![Topup image](../fig/preprocessing/dwi_topup.png)
+![Topup image]({{ relative_root_path }}/fig/preprocessing/dwi_topup.png)
 
 ### FSL [`Eddy`](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddy)
 
@@ -184,7 +184,7 @@ mv ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006
 ~~~
 {: .language-bash}
 
-![T1w brain mask](../fig/preprocessing/T1w_brainmask.png)
+![T1w brain mask]({{ relative_root_path }}/fig/preprocessing/T1w_brainmask.png)
 
 Note, we use <code>bet</code> here, as well as the second inversion of the anatomical image, as it provides us with a better brainmask. The <code>bet</code> command above is called to output only the binary mask and the fractional intensity threshold is also increased slightly (to 0.6) provide a smaller outline of the brain initially, and then decreased (to 0.4) to provide a larger outline. The flag <code>-m</code> indicates to the tool to create a brainmask in addition to outputting the extracted brain volume. Both the mask and brain volume will be used in our registration step.
 
@@ -255,7 +255,7 @@ antsApplyTransforms -d 3 -i ../../data/ds000221/derivatives/uncorrected/sub-0100
 ~~~
 {: .language-bash}
 
-![Transformed volumes](../fig/preprocessing/transformed_volumes.png)
+![Transformed volumes]({{ relative_root_path }}/fig/preprocessing/transformed_volumes.png)
 
 Following the transformation of the T1w volume, we can see that anatomical and diffusion weighted volumes are now aligned. It should be highlighted that as part of the transformation step, the T1w volume is resampled based on the voxel size of the ference volume (e.g. DWI).
 

--- a/_episodes/probabilistic_tractography.md
+++ b/_episodes/probabilistic_tractography.md
@@ -204,7 +204,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![PMF direction getter-derived probabilistic tractogram](../fig/probabilistic_tractography/tractogram_probabilistic_dg_pmf.png){:class="img-responsive"} \
+![PMF direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_pmf.png){:class="img-responsive"} \
 Streamlines representing white matter using probabilistic direction getter from
 PMF
 
@@ -248,7 +248,7 @@ plt.show()
 {: .language-python}
 
 
-![SH direction getter-derived probabilistic tractogram](../fig/probabilistic_tractography/tractogram_probabilistic_dg_sh.png){:class="img-responsive"} \
+![SH direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_sh.png){:class="img-responsive"} \
 Streamlines representing white matter using probabilistic direction getter from
 SH
 
@@ -290,7 +290,7 @@ plt.show()
 {: .language-python}
 
 
-![PMF SH direction getter-derived probabilistic tractogram](../fig/probabilistic_tractography/tractogram_probabilistic_dg_sh_pmf.png){:class="img-responsive"} \
+![PMF SH direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_sh_pmf.png){:class="img-responsive"} \
 Streamlines representing white matter using probabilistic direction getter from
 SH (peaks_from_model)
 


### PR DESCRIPTION
Prefer the `{{ relative_root_path }}` placeholder to resolve figure paths.

Figures need to be located necessarily in a `fig` folder at the root level.
Using the placeholder allows to solve the paths without needing to use any
relative path and regardless of the location of the file containing it.