### PR TITLE
BUG: Mark output cell as Markdown in CSD episode

### DIFF
--- a/code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb
+++ b/code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb
@@ -138,10 +138,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "(array([0.00159258, 0.00033926, 0.00033926]), 209.55229)"
    ]


### PR DESCRIPTION
Mark output cell as Markdown in CSD episode.

Fixes:
```
NameError Traceback (most recent call last)
<ipython-input-1-3cc994cc8588> in <module>
----> 1 (array([0.00159258, 0.00033926, 0.00033926]), 209.55229)

NameError: name 'array' is not defined
```

when running the cell.