### PR TITLE
DOC: Improve the completeness of tractography method list

### DIFF
--- a/_episodes/tractography.md
+++ b/_episodes/tractography.md
@@ -27,17 +27,30 @@ find the curve (i.e. the streamline) that joins them. The streamlines generated
 by a tractography method and the required meta-data are usually saved into files
 called *tractograms*.
 
-The following is a list of the main families of tractography methods:
+The following is a list of the main families of tractography methods in
+chronological order:
 
-* Local tractography (Conturo et al. 1999, Mori et al. 1999, Basser et al. 2000)
-* Particle Filtering Tractography (PFT) (Girard et al. 2014)
+* Local tractography (Conturo et al. 1999, Mori et al. 1999, Basser et al.
+2000).
 * Global tracking (Mangin et al. 2002)
+* Particle Filtering Tractography (PFT) (Girard et al. 2014)
+* Parallel Transport Tractography (PTT) (Aydogan et al., 2019)
 
-The first two methods can use two approaches to propagate the streamlines:
+Local tractography methods and PFT can use two approaches to propagate the
+streamlines:
 - Deterministic: propagates streamlines consistently using the same propagation
 direction.
 - Probabilistic: uses a distribution function to sample from in order to decide
 on the next propagation direction at each step.
+
+Several algorithms exist to perform local tracking, depending on the
+local orientation construct used or the order of the integration being
+performed, among others: FACT (Mori et al. 1999), EuDX (Garyfallidis 2012),
+iFOD1 (Tournier et al. 2012) / iFOD2 (Tournier et al. 2010), and SD_STREAM
+(Tournier et al. 2012) are some of those. Different strategies to reduce the
+uncertainty (or missed configurations) on the tracking results have also been
+proposed (e.g. Ensemble Tractography (Takemura et al. 2016), Bootstrap
+Tractography (Lazar et al. 2005)).
 
 Tractography methods suffer from a number of known biases and limitations,
 generally yielding tractograms containing a large number of prematurely stopped
@@ -45,10 +58,12 @@ streamlines and invalid connections, among others. This results in a hard
 trade-off between sensitivity and specificity (usually measured in the form of
 bundle overlap and overreach) (Maier-Hein et al. 2017).
 
-Several enhancements to the above frameworks have been proposed (e.g. Ensemble
-Tractography (Takemura et al. 2016), Surface-enhanced Tractography (SET)
-(St-Onge et al. 2018), Bundle-Specific Tractography (BST) (Rheault et al.,
-2019), etc.).
+Several enhancements to the above frameworks have been proposed, usually based
+on incorporating some *a priori* knowledge (e.g. Anatomically-Constrained
+Tractography (ACT) (Smith et al. 2012), Structure Tensor Informed Fiber
+Tractography (STIFT) (Kleinnijenhuis et al. 2012), Surface-enhanced
+Tractography (SET) (St-Onge et al. 2018), Bundle-Specific Tractography (BST)
+(Rheault et al., 2019), etc.).
 
 In the recent years, many deep learning methods have been proposed to map the
 local orientation reconstruction (or directly the diffusion MRI data) to long


### PR DESCRIPTION
Improve completeness of tractography method list.

Take advantage of the commit to re-order the method list chronologically.