### PR TITLE
include base_path.html for relative_root_path

### DIFF
--- a/_episodes/constrained_spherical_deconvolution.md
+++ b/_episodes/constrained_spherical_deconvolution.md
@@ -13,6 +13,8 @@ keypoints:
 - "It allows to resolve complex fiber configurations, such as crossings"
 ---
 
+{% include base_path.html %}
+
 ## Constrained Spherical Deconvolution (CSD)
 
 Spherical Deconvolution (SD) is a set of methods to reconstruct the local fiber

--- a/_episodes/deterministic_tractography.md
+++ b/_episodes/deterministic_tractography.md
@@ -12,6 +12,8 @@ keypoints:
 - "Deterministic tractography methods perform tracking in a predictable way"
 ---
 
+{% include base_path.html %}
+
 ## Deterministic tractography
 
 Deterministic tractography algorithms perform tracking of streamlines by

--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -13,6 +13,8 @@ keypoints:
 - "Provides information to infer characteristics of axonal fibres"
 ---
 
+{% include base_path.html %}
+
 ## Diffusion Tensor Imaging (DTI)
 
 Diffusion tensor imaging or "DTI" refers to images describing diffusion with a tensor model. DTI is derived from preprocessed diffusion weighted imaging (DWI) data. First proposed by Basser and colleagues ([Basser, 1994](https://www.ncbi.nlm.nih.gov/pubmed/8130344)), the diffusion tensor model describes diffusion characteristics within an imaging voxel. This model has been very influential in demonstrating the utility of the diffusion MRI in characterizing the microstructure of white matter and the biophysical properties (inferred from local diffusion properties). The DTI model is still a commonly used model to investigate white matter.
@@ -201,9 +203,9 @@ _Sourced from Sotiropoulos and Zalesky (2017). Building connectomes using diffus
 Though other models are outside the scope of this lesson, we recommend looking into some of the pros and cons of each model (listed previously) to choose one best suited for your data!
 
 > ## Exercise 1
-> 
+>
 > Plot the axial and radial diffusivity maps of the example given. Start from fitting the preprocessed diffusion image.
-> 
+>
 > > ## Solution
 > >
 > > ~~~

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -14,6 +14,8 @@ keypoints:
 start: true
 ---
 
+{% include base_path.html %}
+
 ## Diffusion Weighted Imaging (DWI)
 
 Diffusion imaging probes the random, microscopic motion of water protons by employing MRI sequences which are sensitive to the geometry and environmental organization surrounding the water protons. This is a popular technique for studying the white matter of the brain. The diffusion within biological structures, such as the brain, are often restricted due to barriers (eg. cell membranes), resulting in a preferred direction of diffusion (anisotropy). A typical diffusion MRI scan will acquire multiple volumes that are sensitive to a particular diffusion direction and result in diffusion-weighted images (DWI). Diffusion that exhibits directionality in the same direction result in an attenuated signal. With further processing (to be discussed later in the lesson), the acquired images can provide measurements which are related to the microscopic changes and estimate white matter trajectories. Images with no diffusion weighting are also acquired as part of the acquisition protocol.
@@ -316,7 +318,7 @@ array([ True, False, False, False, False, False, False, False, False,
 In the next few notebooks, we will talk more about preprocessing the diffusion weighted images, reconstructing the diffusion tensor model, and reconstruction axonal trajectories via tractography.
 
 > ## Exercise 1
-> 
+>
 > Get a list of **all** diffusion data in NIfTI file format
 >
 > > ## Solution
@@ -328,7 +330,7 @@ In the next few notebooks, we will talk more about preprocessing the diffusion w
 > {: .solution}
 >
 > Get the metadata for the diffusion associated with subject 010016.
-> 
+>
 > > ## Solution
 > >
 > > ~~~

--- a/_episodes/local_orientation_reconstruction.md
+++ b/_episodes/local_orientation_reconstruction.md
@@ -12,6 +12,8 @@ keypoints:
 start: true
 ---
 
+{% include base_path.html %}
+
 ## Orientation reconstruction
 
 Diffusion MRI is sensitive to the underlying white matter fiber orientation

--- a/_episodes/local_tractography.md
+++ b/_episodes/local_tractography.md
@@ -13,6 +13,8 @@ keypoints:
 - "Tractography requires seeds to begin tracking and a stopping criterion for termination"
 ---
 
+{% include base_path.html %}
+
 ## Local tractography
 
 Local tractography algorithms follow 2 general principles:

--- a/_episodes/preprocessing.md
+++ b/_episodes/preprocessing.md
@@ -13,6 +13,8 @@ keypoints:
 start: true
 ---
 
+{% include base_path.html %}
+
 ## Diffusion Preprocessing
 
 Diffusion preprocessing typically comprises of a series of steps, which may vary depending on how the data is acquired. Some consensus has been reached for certain preprocessing steps, while others are still up for debate. The lesson will primarily focus on the preprocessing steps where consensus has been reached. Preprocessing is performed using a few well-known software packages (e.g. FSL, ANTs). For the purposes of these lessons, preprocessing steps requiring these software packages has already been performed for the dataset <code>ds000221</code> and the commands required for each step will be provided. This dataset contains single shell diffusion data with 7 b=0 s/mm^2 volumes (non-diffusion weighted) and 60 b=1000 s/mm^2 volumes. In addition, field maps (found in the <code>fmap</code> directory are acquired with opposite phase-encoding directions).

--- a/_episodes/probabilistic_tractography.md
+++ b/_episodes/probabilistic_tractography.md
@@ -13,6 +13,8 @@ keypoints:
 - "Provides tractograms that explore more white matter axonal fibers"
 ---
 
+{% include base_path.html %}
+
 ## Probabilistic tractography
 
 Probabilistic fiber tracking is a way of reconstructing the white matter

--- a/_episodes/tractography.md
+++ b/_episodes/tractography.md
@@ -12,6 +12,8 @@ keypoints:
 start: true
 ---
 
+{% include base_path.html %}
+
 ## Tractography
 
 The local fiber orientation reconstruction can be used to map the voxel-wise


### PR DESCRIPTION
I noticed that your figures are not appearing on the lesson site. You are correctly using `relative_root_path` to specify the location of your image files, but this variable is only defined in the page if you `include` the `base_path.html` file in the page content. This PR adds that line to the beginning of every episode file, and should result in your images being displayed.

My next task is to document this in the lesson example... 