### PR TITLE
BUG: Fix probabilistic tractography notebook

### DIFF
--- a/code/probabilistic_tractography/probabilistic_tractography.ipynb
+++ b/code/probabilistic_tractography/probabilistic_tractography.ipynb
@@ -28,7 +28,7 @@
     "running time.\n",
     "\n",
     "This episode builds on top of the results of the CSD local orientation\n",
-    "reconstruction method presented in a previous episode."
+    "reconstruction method presented in a previous episode.\n",
     "\n",
     "We will first get the necessary diffusion data, and compute the local\n",
     "orientation information using the CSD method:"
@@ -73,14 +73,14 @@
     "affine = dwi_img.affine\n",
     "\n",
     "bvals, bvecs = read_bvals_bvecs(bval_fname, bvec_fname)\n",
-    "gtab = gradient_table(bvals, bvecs)\n",
+    "gtab = gradient_table(bvals, bvecs)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will now create the seeding mask and the seeds using an estimate of the\n"
+    "We will now create the seeding mask and the seeds using an estimate of the\n",
     "white matter tissue based on the FA values obtained from the diffusion tensor:"
    ]
   },
@@ -104,21 +104,21 @@
     "# This step may take a while\n",
     "dti_fit = dti_model.fit(dwi_data, mask=dwi_mask)\n",
     "\n",
-    "# Create the seeding mask"
+    "# Create the seeding mask\n",
     "fa_img = dti_fit.fa\n",
     "seed_mask = fa_img.copy()\n",
     "seed_mask[seed_mask>=0.2] = 1\n",
     "seed_mask[seed_mask<0.2] = 0\n",
     "\n",
-    "# Create the seeds\n"
-    "seeds = utils.seeds_from_mask(seed_mask, affine=affine, density=1)\n",
+    "# Create the seeds\n",
+    "seeds = utils.seeds_from_mask(seed_mask, affine=affine, density=1)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will now estimate the FRF and set the CSD model to feed the local orientation\n"
+    "We will now estimate the FRF and set the CSD model to feed the local orientation\n",
     "information to the streamline propagation object:"
    ]
   },
@@ -245,7 +245,7 @@
    "metadata": {},
    "source": [
     "![tractogram_probabilistic_dg_pmf](../../fig/probabilistic_tractography/tractogram_probabilistic_dg_pmf.png){:class=\"img-responsive\"} \\\n",
-    "Streamlines representing white matter using probabilistic direction getter\n"
+    "Streamlines representing white matter using probabilistic direction getter\n",
     "from PMF\n",
     "\n",
     "One disadvantage of using a discrete PMF to represent possible tracking\n",
@@ -297,7 +297,7 @@
    "metadata": {},
    "source": [
     "![tractogram_probabilistic_dg_sh](../../fig/probabilistic_tractography/tractogram_probabilistic_dg_sh.png){:class=\"img-responsive\"} \\\n",
-    "Streamlines representing white matter using probabilistic direction getter\n"
+    "Streamlines representing white matter using probabilistic direction getter\n",
     "from SH\n",
     "\n",
     "Not all model fits have the ``shm_coeff`` attribute because not all models use\n",
@@ -345,7 +345,7 @@
    "metadata": {},
    "source": [
     "![tractogram_probabilistic_dg_sh_pmf](../../fig/probabilistic_tractography/tractogram_probabilistic_dg_sh_pmf.png){:class=\"img-responsive\"} \\\n",
-    "Streamlines representing white matter using probabilistic direction getter\n"
+    "Streamlines representing white matter using probabilistic direction getter\n",
     "from SH (peaks_from_model)\n",
     "\n",
     "\n",


### PR DESCRIPTION
Fix probabilistic tractography notebook: the Jupyter engine was unable to parse
the notebook since it was missing some newline/end of line characters (`,`), and
thus did not constitute a valid JSON entity.