### PR TITLE
BUG: Fix deterministic tractography notebook

### DIFF
--- a/code/deterministic_tractography/deterministic_tractography.ipynb
+++ b/code/deterministic_tractography/deterministic_tractography.ipynb
@@ -214,7 +214,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then generate the streamlines 3D scene using the `fury` python package,\n"
+    "We can then generate the streamlines 3D scene using the `fury` python package,\n",
     "and visualize the scene's contents with `matplotlib`."
    ]
   },

--- a/code/deterministic_tractography/solutions/deterministic_tractography_solutions.ipynb
+++ b/code/deterministic_tractography/solutions/deterministic_tractography_solutions.ipynb
@@ -216,7 +216,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can then generate the streamlines 3D scene using the `fury` python package,\n"
+    "We can then generate the streamlines 3D scene using the `fury` python package,\n",
     "and visualize the scene's contents with `matplotlib`."
    ]
   },


### PR DESCRIPTION
Fix deterministic tractography notebook: the Jupyter engine was unable to parse
the notebook since it was missing an end of line characters (`,`), and thus did
not constitute a valid JSON entity.