### PR TITLE
STYLE: Mark numeric cell as Markdown in CSD episode

### DIFF
--- a/code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb
+++ b/code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb
@@ -166,10 +166,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
     "0.21373311340767914"
    ]


### PR DESCRIPTION
Mark numeric cell as Markdown in CSD episode.