### PR TITLE
ENH: Call NiBabel `get_fdata()` instead of `get_data()`

### DIFF
--- a/_episodes/deterministic_tractography.md
+++ b/_episodes/deterministic_tractography.md
@@ -62,7 +62,7 @@ We will now create a mask and constrain the fitting within the mask.
 import dipy.reconst.dti as dti
 from dipy.segment.mask import median_otsu
 
-dwi_data = dwi_img.get_data()
+dwi_data = dwi_img.get_fdata()
 dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1)  # Specify the volume index to the b0 volumes
 
 dti_model = dti.TensorModel(gtab)

--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -96,7 +96,7 @@ Next, we will need to create the tensor model using our gradient table, and then
 import dipy.reconst.dti as dti
 from dipy.segment.mask import median_otsu
 
-dwi_data = dwi_data.get_data()
+dwi_data = dwi_data.get_fdata()
 dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1)
 
 dti_model = dti.TensorModel(gtab)
@@ -231,7 +231,7 @@ Though other models are outside the scope of this lesson, we recommend looking i
 > > gt_bvals, gt_bvecs = read_bvals_bvecs(bval, bvec)
 > > gtab = gradient_table(gt_bvals, gt_bvecs)
 > >
-> > dwi_data = dwi_data.get_data()
+> > dwi_data = dwi_data.get_fdata()
 > > dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1)
 > >
 > > # Fit dti model

--- a/code/deterministic_tractography/deterministic_tractography.ipynb
+++ b/code/deterministic_tractography/deterministic_tractography.ipynb
@@ -64,7 +64,7 @@
     "import dipy.reconst.dti as dti\n",
     "from dipy.segment.mask import median_otsu\n",
     "\n",
-    "dwi_data = dwi_img.get_data()\n",
+    "dwi_data = dwi_img.get_fdata()\n",
     "dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1)  # Specify the volume index to the b0 volumes\n",
     "\n",
     "dti_model = dti.TensorModel(gtab)\n",

--- a/code/diffusion_tensor_imaging/diffusion_tensor_imaging.ipynb
+++ b/code/diffusion_tensor_imaging/diffusion_tensor_imaging.ipynb
@@ -102,7 +102,7 @@
     "import dipy.reconst.dti as dti\n",
     "from dipy.segment.mask import median_otsu\n",
     "\n",
-    "dwi_data = dwi_data.get_data() # We re-use the variable for memory purposes \n",
+    "dwi_data = dwi_data.get_fdata() # We re-use the variable for memory purposes \n",
     "dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1) # Specify the volume index to the b0 volumes\n",
     "\n",
     "dti_model = dti.TensorModel(gtab)\n",

--- a/code/diffusion_tensor_imaging/solutions/diffusion_tensor_imaging_solutions.ipynb
+++ b/code/diffusion_tensor_imaging/solutions/diffusion_tensor_imaging_solutions.ipynb
@@ -122,7 +122,7 @@
     "import dipy.reconst.dti as dti\n",
     "from dipy.segment.mask import median_otsu\n",
     "\n",
-    "dwi_data = dwi_data.get_data() # We re-use the variable for memory purposes \n",
+    "dwi_data = dwi_data.get_fdata() # We re-use the variable for memory purposes \n",
     "dwi_data, dwi_mask = median_otsu(dwi_data, vol_idx=[0], numpass=1) # Specify the volume index to the b0 volumes\n",
     "\n",
     "dti_model = dti.TensorModel(gtab)\n",


### PR DESCRIPTION
Call NiBabel `get_fdata()` instead of `get_data()`.

Given that we do not specify the `NiBabel` version in the requirements file, the
latest version will be used.

Fixes:
```
DeprecationWarning: get_data() is deprecated in favor of get_fdata(), which has
a more predictable return type. To obtain get_data() behavior going forward, use
numpy.asanyarray(img.dataobj).\n\n* deprecated from version: 3.0\n* Will raise
<class 'nibabel.deprecator.ExpiredDeprecationError'> as of version: 5.0\n  after
removing the cwd from sys.path.\n"
```