### PR TITLE
DOC: Add info about downloading single subject from OSF

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -46,10 +46,13 @@ jobs:
     # Download the necessary data
     - name: Download data
       run: |
-        osf -p cmq8a clone ${{ github.workspace }}/data
-        mv ${{ github.workspace }}/data/osfstorage/* ${{ github.workspace }}/data
-        rm -rf ${{ github.workspace }}/data/osfstorage
-
+        pushd `pwd`
+        cd ${{ github.workspace }}/data
+        osf -p cmq8a fetch ds000221_subject/ds000221_sub-010006.zip
+        unzip ds000221_sub-010006.zip 
+        rm ds000221_subject/ds000221_sub-010006.zip
+        popd 
+        
     # Run the actual tests of all the Python Notebooks.
     - name: Test Notebooks
       run: |

--- a/setup.md
+++ b/setup.md
@@ -169,7 +169,17 @@ $ osf -p cmq8a clone ./data
 {: .bash}
 
 Notebooks expect them to be placed in the `data` folder that exists in the root
-of the repository.
+of the repository. 
+
+Note the above command clones the entire repository, which may be quite large and
+take a while to download. Alternatively, data from a single subject is available
+and can be downloaded by running:
+~~~
+$ cd ./data
+$ osf -p cmq8a fetch ds000221_subject/ds000221_sub-010006.zip 
+$ unzip sub-010006.zip
+~~~
+{: .bash}
 
 
 {% include links.md %}

--- a/setup.md
+++ b/setup.md
@@ -171,7 +171,7 @@ $ osf -p cmq8a clone ./data
 Notebooks expect them to be placed in the `data` folder that exists in the root
 of the repository. 
 
-Note the above command clones the entire repository, which may be quite large and
+Note that the above command clones the entire repository, which may be quite large and
 take a while to download. Alternatively, data from a single subject is available
 and can be downloaded by running:
 ~~~


### PR DESCRIPTION
Added a single subject zip file to the OSF. Using `clone` clones the entire repository, which may take a while, while using `fetch` only allows you to download a single file at a time. 

Added instructions to use `fetch` to download and unzip this single subject zip, which contains all the preprocessed data for `sub-010006`