### PR TITLE
STY: Update DTI notebook

### DIFF
--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -86,7 +86,7 @@ The different algorithms implemented in the module all share a similar conceptua
 
 * <code>ReconstModel</code> objects (e.g. <code>TensorModel</code>) carry the parameters that 
 are required in order to fit a model. For example, the directions and magnitudes of the gradients 
-that were applied in the experiment. <code>TensorModel> objects have a <code>fit</code> method, which takes 
+that were applied in the experiment. <code>TensorModel</code> objects have a <code>fit</code> method, which takes 
 in data, and returns a <code>ReconstFit</code> object. This is where a lot of the heavy lifting 
 of the processing will take place.
 * <code>ReconstFit</code> objects carry the model that was used to generate the object. 

--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -86,7 +86,7 @@ The different algorithms implemented in the module all share a similar conceptua
 
 * <code>ReconstModel</code> objects (e.g. <code>TensorModel</code>) carry the parameters that 
 are required in order to fit a model. For example, the directions and magnitudes of the gradients 
-that were applied in the experiment. The objects all have a <code>fit</code> method, which takes 
+that were applied in the experiment. <code>TensorModel> objects have a <code>fit</code> method, which takes 
 in data, and returns a <code>ReconstFit</code> object. This is where a lot of the heavy lifting 
 of the processing will take place.
 * <code>ReconstFit</code> objects carry the model that was used to generate the object. 

--- a/code/diffusion_tensor_imaging/diffusion_tensor_imaging.ipynb
+++ b/code/diffusion_tensor_imaging/diffusion_tensor_imaging.ipynb
@@ -234,7 +234,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another way of viewing the tensors is to visualize the diffusion tensor in each imaging voxel with colour encoding (we will refer you to the [`Dipy` documentation](https://dipy.org/tutorials/) for the steps to perform this type of visualization as it can be memory intensive). Below is an example image of such tensor visualization.\n",
+    "Another way of viewing the tensors is to visualize the diffusion tensor in each imaging voxel with colour encoding (we will refer you to the [`DIPY` documentation](https://dipy.org/tutorials/) for the steps to perform this type of visualization as it can be memory intensive). Below is an example image of such tensor visualization.\n",
     "\n",
     "![Tensor Visualization](../../fig/diffusion_tensor_imaging/TensorViz.png)"
    ]

--- a/code/diffusion_tensor_imaging/diffusion_tensor_imaging.ipynb
+++ b/code/diffusion_tensor_imaging/diffusion_tensor_imaging.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "The different algorithms implemented in the module all share a similar conceptual structure:\n",
     "\n",
-    "* `ReconstModel` objects (e.g. `TensorModel`) carry the parameters that are required in order to fit a model. For example, the directions and magnitudes of the gradients that were applied in the experiment. The objects all have a `fit` method, which takes in data, and returns a `ReconstFit` object. This is where a lot of the heavy lifting of the processing will take place.\n",
+    "* `ReconstModel` objects (e.g. `TensorModel`) carry the parameters that are required in order to fit a model. For example, the directions and magnitudes of the gradients that were applied in the experiment. `TensorModel` objects have a `fit` method, which takes in data, and returns a `ReconstFit` object. This is where a lot of the heavy lifting of the processing will take place.\n",
     "* `ReconstFit` objects carry the model that was used to generate the object. They also include the parameters that were estimated during fitting of the data. They have methods to calculate derived statistics, which can differ from model to model. All objects also have an orientation distribution function (`odf`), and most (but not all) contain a `predict` method, which enables the prediction of another dataset based on the current gradient table.\n"
    ]
   },

--- a/code/diffusion_tensor_imaging/solutions/diffusion_tensor_imaging_solutions.ipynb
+++ b/code/diffusion_tensor_imaging/solutions/diffusion_tensor_imaging_solutions.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "The different algorithms implemented in the module all share a similar conceptual structure:\n",
     "\n",
-    "* `ReconstModel` objects (e.g. `TensorModel`) carry the parameters that are required in order to fit a model. For example, the directions and magnitudes of the gradients that were applied in the experiment. The objects all have a `fit` method, which takes in data, and returns a `ReconstFit` object. This is where a lot of the heavy lifting of the processing will take place.\n",
+    "* `ReconstModel` objects (e.g. `TensorModel`) carry the parameters that are required in order to fit a model. For example, the directions and magnitudes of the gradients that were applied in the experiment. `TensorModel` objects have a `fit` method, which takes in data, and returns a `ReconstFit` object. This is where a lot of the heavy lifting of the processing will take place.\n",
     "* `ReconstFit` objects carry the model that was used to generate the object. They also include the parameters that were estimated during fitting of the data. They have methods to calculate derived statistics, which can differ from model to model. All objects also have an orientation distribution function (`odf`), and most (but not all) contain a `predict` method, which enables the prediction of another dataset based on the current gradient table.\n"
    ]
   },


### PR DESCRIPTION
Addresses previously missed comment about sentence structure and also missed `DIPY` capitalization in the Jupyter notebook.

@jhlegarreta you'll have to let me know what else is missed - hard for me to see the differences despite going through the notebooks and markdown file side-by-side. 