### PR TITLE
FIX: Update pythonpath

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -42,7 +42,7 @@ jobs:
         virtualenv ~/sdc_bids_dmri
         pip install -r requirements.txt
         pip install pytest nbval
-        export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}/utils`
+        export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}`
 
     # Download the necessary data
     - name: Download data

--- a/setup.md
+++ b/setup.md
@@ -90,7 +90,7 @@ from the root of the repository folder.
 Additionally, a helpful module to view anatomical slices have been included in the
 `utils` folder. To use this in python, run the following command:
 ~~~
-$ export PYTHONPATH=$PYTHONPATH:`realpath ./utils`
+$ export PYTHONPATH=$PYTHONPATH:`realpath .`
 ~~~
 {: .bash}
 


### PR DESCRIPTION
This should actually resolve #129 now. Previous `PYTHONPATH` included the `utils` directory which threw a `ModuleNotFound` when imported outside of parent directory given the way the code is currently setup. 

To avoid having to go through and update all of the paths, update the path to include the parent directory instead. Testing the updated path in jupyter seems to have worked.