### PR TITLE
FIX: Actions workflow - rm zip

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -51,7 +51,7 @@ jobs:
         cd ${{ github.workspace }}/data
         osf -p cmq8a fetch ds000221_subject/ds000221_sub-010006.zip
         unzip ds000221_sub-010006.zip 
-        rm ds000221_subject/ds000221_sub-010006.zip
+        rm ds000221_sub-010006.zip
         popd 
         
     # Run the actual tests of all the Python Notebooks.


### PR DESCRIPTION
Noticed the latest CI run was unsuccessful after failing to remove the zip due to an incorrect path. This PR updates the path to remove the downloaded zip.