### PR TITLE
ENH: Split appart visualization cell in CSD exercise

### DIFF
--- a/code/constrained_spherical_deconvolution/solutions/constrained_spherical_deconvolution_solutions.ipynb
+++ b/code/constrained_spherical_deconvolution/solutions/constrained_spherical_deconvolution_solutions.ipynb
@@ -568,8 +568,51 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will first simulate the ODFs for the different crossing angles:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from dipy.data import get_sphere\n",
+    "from dipy.sims.voxel import multi_tensor_odf\n",
+    "\n",
+    "# Set eigenvalues for tensors\n",
+    "mevals = np.array(([0.0015, 0.00015, 0.00015], [0.0015, 0.00015, 0.00015]))\n",
+    "\n",
+    "# Set fraction for each tensor\n",
+    "fractions = [50, 50]\n",
+    "\n",
+    "angles = [90, 60, 45, 30, 20]\n",
+    "\n",
+    "odf = []\n",
+    "\n",
+    "# Simulate ODFs of different angles\n",
+    "for angle in angles:\n",
+    "    _angles = [(0, 0), (angle, 0)]\n",
+    "    _odf = multi_tensor_odf(get_sphere(\n",
+    "        \"repulsion724\").vertices, mevals, _angles, fractions)\n",
+    "    odf.append(_odf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are now able to visualize and save to disk a screenshot of each ODF crossing. As it can be seen, as the crossing angle becomes smaller, distinguishing the underlying fiber orientations becomes harder: an ODF might be unable to resolve different fiber populations at such crossings, and be only able to indicate a single orientation. This has an impact on tractography, since the tracking procedure will only be able to propagate streamlines according to peaks retrieved by the ODFs. Also, note that this problem is worsened by the presence of noise in real diffusion data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -586,13 +629,11 @@
     }
    ],
    "source": [
+    "# NBAL_SKIP\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "import numpy as np\n",
-    "\n",
-    "from dipy.data import get_sphere\n",
-    "from dipy.viz import window, actor\n",
-    "from dipy.sims.voxel import multi_tensor_odf\n",
+    "from fury import window, actor\n",
     "\n",
     "# Create the output directory to store the image\n",
     "out_dir = '../../../data/ds000221/derivatives/dwi/reconstruction/exercise/dwi/'\n",
@@ -600,21 +641,12 @@
     "if not os.path.exists(out_dir):\n",
     "    os.makedirs(out_dir)\n",
     "\n",
-    "# Set eigenvalues for tensors\n",
-    "mevals = np.array(([0.0015, 0.00015, 0.00015], [0.0015, 0.00015, 0.00015]))\n",
+    "fig, axes = plt.subplots(1, len(angles), figsize=(10, 2))\n",
     "\n",
-    "# Set fraction for each tensor\n",
-    "fractions = [50, 50]\n",
-    "\n",
-    "fig, axes = plt.subplots(1, 5, figsize=(10, 2))\n",
-    "\n",
-    "# Simulate ODF of different angles\n",
-    "for ix, angle in enumerate([90, 60, 45, 30, 20]):\n",
-    "    angles = [(0, 0), (angle, 0)]\n",
-    "    odf = multi_tensor_odf(get_sphere(\n",
-    "        \"repulsion724\").vertices, mevals, angles, fractions)\n",
+    "# Visualize the simulated ODFs of different angles\n",
+    "for ix, (_odf, angle) in enumerate(zip(odf, angles)):\n",
     "    scene = window.Scene()\n",
-    "    odf_actor = actor.odf_slicer(odf[None, None, None, :], sphere=get_sphere(\"repulsion724\"),\n",
+    "    odf_actor = actor.odf_slicer(_odf[None, None, None, :], sphere=get_sphere(\"repulsion724\"),\n",
     "                                 colormap='plasma')\n",
     "    odf_actor.RotateX(90)\n",
     "    scene.add(odf_actor)\n",


### PR DESCRIPTION
Split appart the visualization part from the ODF computation part in the CSD
episode exercise.

Mark the visualization cell to be skipped in the tests.

Take advantage of the commit to provide an explanation to the result of the
exercise.