### PR TITLE
STYLE: Limit line length in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,19 @@ Python.
 
 ## Why Python?
 
-Python is rapidly becoming the standard language for data analysis, visualization and automated workflow building. It is a free and open-source software that is relatively easy to pick up by new programmers. In addition, with Python packages such as `Jupyter` one can keep an interactive code journal of analysis - this is what we'll be using in the workshop. Using Jupyter notebooks allows you to keep a record of all the steps in your analysis, enabling transparency and ease of code sharing.
+Python is rapidly becoming the standard language for data analysis,
+visualization and automated workflow building. It is a free and open-source
+software that is relatively easy to pick up by new programmers. In addition,
+with Python packages such as `Jupyter` one can keep an interactive code journal
+of analysis - this is what we'll be using in the workshop. Using Jupyter
+notebooks allows you to keep a record of all the steps in your analysis,
+enabling transparency and ease of code sharing.
 
-Another advantage of Python is that it is maintained by a large user-base. Anyone can easily make their own Python packages for others to use. Therefore, there exists a *very* large codebase for you to take advantage of for your neuroimaging analysis; from basic statistical analysis, to brain visualization tools, to advanced machine learning and multivariate methods!
+Another advantage of Python is that it is maintained by a large user-base.
+Anyone can easily make their own Python packages for others to use. Therefore,
+there exists a *very* large codebase for you to take advantage of for your
+neuroimaging analysis; from basic statistical analysis, to brain visualization
+tools, to advanced machine learning and multivariate methods!
 
 ## About the Lesson
 

--- a/_episodes/constrained_spherical_deconvolution.md
+++ b/_episodes/constrained_spherical_deconvolution.md
@@ -232,7 +232,8 @@ csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=sh_order, c
 ~~~
 {: .language-python}
 
-For illustration purposes we will fit only a small portion of the data representing the splenium of the corpus callosum.
+For illustration purposes we will fit only a small portion of the data
+representing the splenium of the corpus callosum.
 
 ~~~
 data_small = data[40:80, 40:80, 45:55]
@@ -241,7 +242,8 @@ csd_fit = csd_model.fit(data_small)
 sh_coeffs = csd_fit.shm_coeff
 
 # Save the SH coefficients
-nib.save(nib.Nifti1Image(sh_coeffs.astype(np.float32), affine), os.path.join(out_dir, 'sh_coeffs.nii.gz'))
+nib.save(nib.Nifti1Image(sh_coeffs.astype(np.float32), affine),
+         os.path.join(out_dir, 'sh_coeffs.nii.gz'))
 ~~~
 {: .language-python}
 

--- a/_episodes/deterministic_tractography.md
+++ b/_episodes/deterministic_tractography.md
@@ -135,7 +135,9 @@ this value).
 ~~~
 from dipy.direction import peaks_from_model
 
-peak_indices = peaks_from_model(model=dti_model, data=dwi_data, sphere=sphere, relative_peak_threshold=.2, min_separation_angle=25, mask=dwi_mask, npeaks=2)
+peak_indices = peaks_from_model(
+    model=dti_model, data=dwi_data, sphere=sphere, relative_peak_threshold=.2,
+    min_separation_angle=25, mask=dwi_mask, npeaks=2)
 ~~~
 {: .language-python}
 
@@ -178,7 +180,8 @@ from dipy.tracking.local_tracking import LocalTracking
 from dipy.tracking.streamline import Streamlines
 
 # Initialize local tracking - computation happens in the next step.
-streamlines_generator = LocalTracking(peak_indices, stopping_criterion, seeds, affine=affine, step_size=.5)
+streamlines_generator = LocalTracking(
+    peak_indices, stopping_criterion, seeds, affine=affine, step_size=.5)
 
 # Generate streamlines object
 streamlines = Streamlines(streamlines_generator)
@@ -286,8 +289,11 @@ plt.show()
 > > evecs_img = dti_fit.evecs
 > > 
 > > sphere = get_sphere('symmetric362')
-> > peak_indices = peaks_from_model(model=dti_model, data=dwi_data, sphere=sphere, relative_peak_threshold=.2, min_separation_angle=25, mask=dwi_mask, npeaks=2)
-> > 
+> > peak_indices = peaks_from_model(
+> >        model=dti_model, data=dwi_data, sphere=sphere,
+> >        relative_peak_threshold=.2, min_separation_angle=25, mask=dwi_mask,
+> >        npeaks=2)
+> >
 > > # Create a binary seed mask
 > > seed_mask = fa_img.copy()
 > > seed_mask[seed_mask >= 0.2] = 1
@@ -299,7 +305,8 @@ plt.show()
 > > stopping_criterion = BinaryStoppingCriterion(seed_mask==1)
 > > 
 > > # Perform tracking
-> > streamlines_generator = LocalTracking(peak_indices, stopping_criterion, seeds, affine=affine, step_size=.5)
+> > streamlines_generator = LocalTracking(
+> >     peak_indices, stopping_criterion, seeds, affine=affine, step_size=.5)
 > > streamlines = Streamlines(streamlines_generator)
 > >
 > > # Plot the tractogram

--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -86,9 +86,9 @@ The different algorithms implemented in the module all share a similar conceptua
 
 * <code>ReconstModel</code> objects (e.g. <code>TensorModel</code>) carry the parameters that 
 are required in order to fit a model. For example, the directions and magnitudes of the gradients 
-that were applied in the experiment. <code>TensorModel</code> objects have a <code>fit</code> method, which takes 
-in data, and returns a <code>ReconstFit</code> object. This is where a lot of the heavy lifting 
-of the processing will take place.
+that were applied in the experiment. <code>TensorModel</code> objects have a <code>fit</code>
+method, which takes  in data, and returns a <code>ReconstFit</code> object. This is where a lot of
+the heavy lifting of the processing will take place.
 * <code>ReconstFit</code> objects carry the model that was used to generate the object. 
 They also include the parameters that were estimated during fitting of the data. They have 
 methods to calculate derived statistics, which can differ from model to model. All objects also 
@@ -98,7 +98,9 @@ current gradient table.
 
 ### Reconstruction with the DTI Model
 
-Let's get started! First, we will need to grab the **preprocessed** DWI files and load them! We will also load in the anatomical image to use as a reference later on.
+Let's get started! First, we will need to grab the **preprocessed** DWI files
+and load them! We will also load in the anatomical image to use as a reference
+later on.
 
 ~~~
 from bids.layout import BIDSLayout
@@ -295,7 +297,8 @@ data!
 
 > ## Exercise 1
 >
-> Plot the axial and radial diffusivity maps of the example given. Start from fitting the preprocessed diffusion image.
+> Plot the axial and radial diffusivity maps of the example given. Start from
+> fitting the preprocessed diffusion image.
 >
 > > ## Solution
 > >

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -18,18 +18,40 @@ start: true
 
 ## Diffusion Weighted Imaging (DWI)
 
-Diffusion imaging probes the random, microscopic motion of water protons by employing MRI sequences which are sensitive to the geometry and environmental organization surrounding the water protons. This is a popular technique for studying the white matter of the brain. The diffusion within biological structures, such as the brain, are often restricted due to barriers (eg. cell membranes), resulting in a preferred direction of diffusion (anisotropy). A typical diffusion MRI scan will acquire multiple volumes that are sensitive to a particular diffusion direction and result in diffusion-weighted images (DWI). Diffusion that exhibits directionality in the same direction result in an attenuated signal. With further processing (to be discussed later in the lesson), the acquired images can provide measurements which are related to the microscopic changes and estimate white matter trajectories. Images with no diffusion weighting are also acquired as part of the acquisition protocol.
+Diffusion imaging probes the random, microscopic motion of water protons by
+employing MRI sequences which are sensitive to the geometry and environmental
+organization surrounding the water protons. This is a popular technique for
+studying the white matter of the brain. The diffusion within biological
+structures, such as the brain, are often restricted due to barriers (e.g. cell
+membranes), resulting in a preferred direction of diffusion (anisotropy). A
+typical diffusion MRI scan will acquire multiple volumes that are sensitive to
+a particular diffusion direction and result in diffusion-weighted images (DWI).
+Diffusion that exhibits directionality in the same direction result in an
+attenuated signal. With further processing (to be discussed later in the
+lesson), the acquired images can provide measurements which are related to the
+microscopic changes and estimate white matter trajectories. Images with no
+diffusion weighting are also acquired as part of the acquisition protocol.
 
 ![Diffusion along X, Y, and Z directions]({{ relative_root_path }}/fig/introduction/DiffusionDirections.png){:class="img-responsive"} \
 Diffusion along X, Y, and Z directions
 
 ## b-values & b-vectors
 
-In addition to the acquired diffusion images, two files are collected as part of the diffusion dataset. These files correspond to the gradient amplitude (b-values) and directions (b-vectors) of the diffusion measurement and are named with the extensions <code>.bval</code> and <code>.bvec</code> respectively. The b-value is the diffusion-sensitizing factor, and reflects the timing & strength of the gradients used to acquire the diffusion-weighted images. The b-vector corresponds to the direction of the diffusion sensitivity. Together these two files define the diffusion MRI measurement as a set of gradient directions and corresponding amplitudes.
+In addition to the acquired diffusion images, two files are collected as part
+of the diffusion dataset. These files correspond to the gradient amplitude
+(b-values) and directions (b-vectors) of the diffusion measurement and are
+named with the extensions <code>.bval</code> and <code>.bvec</code>
+respectively. The b-value is the diffusion-sensitizing factor, and reflects the
+timing & strength of the gradients used to acquire the diffusion-weighted
+images. The b-vector corresponds to the direction of the diffusion sensitivity.
+Together these two files define the diffusion MRI measurement as a set of
+gradient directions and corresponding amplitudes.
 
 ## Dataset
 
-Below is a tree diagram showing the folder structure of a single MR subject and session within ds000221. This was obtained by using the bash command <code>tree<code>.
+Below is a tree diagram showing the folder structure of a single MR subject and
+session within ds000221. This was obtained by using the bash command
+<code>tree<code>.
 
 ~~~
 tree '../data/ds000221'
@@ -96,9 +118,12 @@ tree '../data/ds000221'
 
 ## Querying a BIDS Dataset
 
-[`pybids`](https://bids-standard.github.io/pybids/) is a Python API for querying, summarizing and manipulating the BIDS folder structure. We will make use of <code>pybids</code> to query the necessary files.
+[`pybids`](https://bids-standard.github.io/pybids/) is a Python API for
+querying, summarizing and manipulating the BIDS folder structure. We will make
+use of <code>pybids</code> to query the necessary files.
 
-Lets first pull the metadata from its associated JSON file using the <code>get_metadata()</code> function for the first run.
+Lets first pull the metadata from its associated JSON file using the
+<code>get_metadata()</code> function for the first run.
 
 ~~~
 from bids.layout import BIDSLayout
@@ -107,7 +132,8 @@ layout = BIDSLayout("../data/ds000221", validate=False)
 ~~~
 {: .language-python}
 
-Now that we have a layout object, we can work with a BIDS dataset! Lets extract the metadata. from the dataset.
+Now that we have a layout object, we can work with a BIDS dataset! Lets extract
+the metadata. from the dataset.
 
 ~~~
 dwi = layout.get(subject='010006', suffix='dwi', extension='nii.gz', return_type='file')[0]
@@ -135,7 +161,8 @@ layout.get_metadata(dwi)
 
 ## Diffusion Imaging in Python ([dipy](https://dipy.org))
 
-For this lesson, we will use the <code>Dipy</code> (Diffusion Imaging in Python) package for processing and analysing diffusion MRI.
+For this lesson, we will use the <code>Dipy</code> (Diffusion Imaging in
+Python) package for processing and analysing diffusion MRI.
 
 ### Why <code>dipy</code>?
 
@@ -146,13 +173,21 @@ For this lesson, we will use the <code>Dipy</code> (Diffusion Imaging in Python)
 
 ### Installing <code>dipy</code>
 
-The easiest way to install <code>Dipy</code> is to use <code>pip</code>! Additionally, <code>Dipy</code> makes use of the FURY library for visualization. We will also install this using <code>pip</code>!
+The easiest way to install <code>Dipy</code> is to use <code>pip</code>!
+Additionally, <code>Dipy</code> makes use of the FURY library for
+visualization. We will also install this using <code>pip</code>!
 
-We can install it by entering the following in a terminal <code>pip install dipy</code>. We will do so using Jupyter Magic in the following cell!
+We can install it by entering the following in a terminal
+<code>pip install dipy</code>. We will do so using Jupyter Magic in the
+following cell!
 
 ### Defining a measurement: <code>GradientTable</code>
 
-<code>Dipy</code> has a built-in function that allows us to read in <code>bval</code> and <code>bvec</code> files named <code>read_bvals_bvecs</code> under the <code>dipy.io.gradients</code> module. Let's first grab the path to our gradient directions and amplitude files and load them into memory.
+<code>Dipy</code> has a built-in function that allows us to read in
+<code>bval</code> and <code>bvec</code> files named
+<code>read_bvals_bvecs</code> under the <code>dipy.io.gradients</code> module.
+Let's first grab the path to our gradient directions and amplitude files and
+load them into memory.
 
 ~~~
 bvec = layout.get_bvec(dwi)
@@ -179,7 +214,9 @@ data.shape
 ~~~
 {: .output}
 
-We can see that the data is 4 dimensional. The 4th dimension represents the different diffusion directions we are sensitive to. Next, let's take a look at a slice.
+We can see that the data is 4 dimensional. The 4th dimension represents the
+different diffusion directions we are sensitive to. Next, let's take a look at
+a slice.
 
 ~~~
 x_slice = data[58, :, :, 0]
@@ -196,7 +233,9 @@ for i, slice in enumerate(slices):
 
 ![DWI slice]({{ relative_root_path }}/fig/introduction/dwi_slice.png){:class="img-responsive"}
 
-We can also see how the diffusion gradients are represented. This is plotted on a sphere, the further away from the center of the sphere, the stronger the diffusion gradient (increased sensitivity to diffusion).
+We can also see how the diffusion gradients are represented. This is plotted on
+a sphere, the further away from the center of the sphere, the stronger the
+diffusion gradient (increased sensitivity to diffusion).
 
 ~~~
 bvec_txt = np.genfromtxt(bvec)
@@ -209,7 +248,12 @@ ax.scatter(bvec_txt[0], bvec_txt[1], bvec_txt[2])
 
 ![Diffusion gradient sphere]({{ relative_root_path }}/fig/introduction/diffusion_gradient.png){:class="img-responsive"}
 
-The files associated with the diffusion gradients need to converted to a <code>GradientTable</code> object to be used with <code>Dipy</code>. A <code>GradientTable</code> object can be implemented using the <code>dipy.core.gradients</code> module. The input to the <code>GradientTable</code> should be our the values for our gradient directions and amplitudes we read in.
+The files associated with the diffusion gradients need to converted to a
+<code>GradientTable</code> object to be used with <code>Dipy</code>. A
+<code>GradientTable</code> object can be implemented using the
+<code>dipy.core.gradients</code> module. The input to the
+<code>GradientTable</code> should be our the values for our gradient directions
+and amplitudes we read in.
 
 ~~~
 from dipy.io.gradients import read_bvals_bvecs
@@ -220,9 +264,13 @@ gtab = gradient_table(gt_bvals, gt_bvecs)
 ~~~
 {: .language-python}
 
-We will need this gradient table later on to process our data and generate diffusion tensor images (DTI)!
+We will need this gradient table later on to process our data and generate
+diffusion tensor images (DTI)!
 
-There is also a built in function for gradient tables, <code>b0s_mask</code> that can be used to separate diffusion weighted measurements from non-diffusion weighted measurements (b=0s/mm^2). We will extract the vector corresponding to diffusion weighted measurements!
+There is also a built in function for gradient tables, <code>b0s_mask</code>
+that can be used to separate diffusion weighted measurements from non-diffusion
+weighted measurements (b=0s/mm^2). We will extract the vector corresponding to
+diffusion weighted measurements!
 
 ~~~
 gtab.bvecs[~gtab.b0s_mask]
@@ -293,7 +341,9 @@ array([[ 0.0480948 , -0.518981  ,  0.853432  ],
 ~~~
 {: .output}
 
-It is also important to know where our diffusion weighting free measurements are as we need them for registration in our preprocessing, (our next notebook). The gtab.b0s_mask shows that this is our first volume of our dataset.
+It is also important to know where our diffusion weighting free measurements
+are as we need them for registration in our preprocessing, (our next notebook).
+The gtab.b0s_mask shows that this is our first volume of our dataset.
 
 ~~~
 gtab.b0s_mask
@@ -312,7 +362,9 @@ array([ True, False, False, False, False, False, False, False, False,
 ~~~
 {: .output}
 
-In the next few notebooks, we will talk more about preprocessing the diffusion weighted images, reconstructing the diffusion tensor model, and reconstruction axonal trajectories via tractography.
+In the next few notebooks, we will talk more about preprocessing the diffusion
+weighted images, reconstructing the diffusion tensor model, and reconstruction
+axonal trajectories via tractography.
 
 > ## Exercise 1
 >

--- a/_episodes/preprocessing.md
+++ b/_episodes/preprocessing.md
@@ -17,14 +17,28 @@ start: true
 
 ## Diffusion Preprocessing
 
-Diffusion preprocessing typically comprises of a series of steps, which may vary depending on how the data is acquired. Some consensus has been reached for certain preprocessing steps, while others are still up for debate. The lesson will primarily focus on the preprocessing steps where consensus has been reached. Preprocessing is performed using a few well-known software packages (e.g. FSL, ANTs). For the purposes of these lessons, preprocessing steps requiring these software packages has already been performed for the dataset <code>ds000221</code> and the commands required for each step will be provided. This dataset contains single shell diffusion data with 7 b=0 s/mm^2 volumes (non-diffusion weighted) and 60 b=1000 s/mm^2 volumes. In addition, field maps (found in the <code>fmap</code> directory are acquired with opposite phase-encoding directions).
+Diffusion preprocessing typically comprises of a series of steps, which may vary
+depending on how the data is acquired. Some consensus has been reached for
+certain preprocessing steps, while others are still up for debate. The lesson
+will primarily focus on the preprocessing steps where consensus has been
+reached. Preprocessing is performed using a few well-known software packages
+(e.g. FSL, ANTs). For the purposes of these lessons, preprocessing steps
+requiring these software packages has already been performed for the dataset
+<code>ds000221</code> and the commands required for each step will be provided.
+This dataset contains single shell diffusion data with 7 b=0 s/mm^2 volumes
+(non-diffusion weighted) and 60 b=1000 s/mm^2 volumes. In addition, field maps
+(found in the <code>fmap</code> directory are acquired with opposite
+phase-encoding directions).
 
-To illustrate what the preprocessing step may look like, here is an example preprocessing workflow from QSIPrep (Cieslak _et al_, 2020):
+To illustrate what the preprocessing step may look like, here is an example
+preprocessing workflow from QSIPrep (Cieslak _et al_, 2020):
 ![Preprocessing steps]({{ relative_root_path }}/fig/preprocessing/preprocess_steps.jpg)
 
-dMRI has some similar challenges to fMRI preprocessing, as well as some unique [ones](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3366862/).
+dMRI has some similar challenges to fMRI preprocessing, as well as some unique
+[ones](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3366862/).
 
-Our preprocesssing of this data will consist of following steps and will make use of sub-010006:
+Our preprocesssing of this data will consist of following steps and will make
+use of sub-010006:
 1. Brainmasking the diffusion data
 2. Applying FSL `topup` to correct for susceptibility induced distortions
 3. FSL Eddy current distortion correction
@@ -32,7 +46,11 @@ Our preprocesssing of this data will consist of following steps and will make us
 
 ### Brainmasking
 
-The first step to the preprocessing workflow is to create an appropriate brainmask from the diffusion data! Start, by first importing the necessary modules. and reading the diffusion data! We will also grab the anatomical T1w image to use later on, as well as the second inversion from the anatomical acquisition for brainmasking purposes.
+The first step to the preprocessing workflow is to create an appropriate
+brainmask from the diffusion data! Start, by first importing the necessary
+modules. and reading the diffusion data! We will also grab the anatomical T1w
+image to use later on, as well as the second inversion from the anatomical
+acquisition for brainmasking purposes.
 
 ~~~
 from bids.layout import BIDSLayout
@@ -59,7 +77,12 @@ dwi_data = dwi.get_fdata()
 ~~~
 {: .language-python}
 
-DIPY's <code>segment.mask</code> module will be used to create a brainmask from this. This module contains a function <code>median_otsu</code>, which can be used to segment the brain and provide a binary brainmask! Here, a brainmask will be created using the first non-diffusion volume of the data. We will save this brainmask to be used in our later future preprocessing steps. After creating the brainmask, we will start to correct for distortions in our images.
+DIPY's <code>segment.mask</code> module will be used to create a brainmask
+from this. This module contains a function <code>median_otsu</code>, which can
+be used to segment the brain and provide a binary brainmask! Here, a brainmask
+will be created using the first non-diffusion volume of the data. We will save
+this brainmask to be used in our later future preprocessing steps. After
+creating the brainmask, we will start to correct for distortions in our images.
 
 ~~~
 import os
@@ -84,11 +107,27 @@ nib.save(img, os.path.join(out_dir, "sub-%s_ses-01_brainmask.nii.gz" % subj))
 
 ### FSL [<code>topup</code>](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/topup)
 
-Diffusion images, typically acquired using spin-echo echo planar imaging (EPI), are sensitive to non-zero off-resonance fields. One source of these fields is from the susceptibilitiy distribution of the subjects head, otherwise known as susceptibility-induced off-resonance field. This field is approximately constant for all acquired diffusion images. As such, for a set of diffusion volumes, the susceptibility-induced field will be consistent throughout. This is mainly a problem due to geometric mismatches with the anatomical images (e.g. T1w), which are typically unaffected by such distortions.
+Diffusion images, typically acquired using spin-echo echo planar imaging (EPI),
+are sensitive to non-zero off-resonance fields. One source of these fields is
+from the susceptibilitiy distribution of the subjects head, otherwise known as
+susceptibility-induced off-resonance field. This field is approximately
+constant for all acquired diffusion images. As such, for a set of diffusion
+volumes, the susceptibility-induced field will be consistent throughout. This
+is mainly a problem due to geometric mismatches with the anatomical images
+(e.g. T1w), which are typically unaffected by such distortions.
 
-<code>topup</code>, part of the FSL library, estimates and attempts to correct the susceptibility-induced off-resonance field by using 2 (or more) acquisitions, where the acquisition parameters differ such that the distortion differs. Typically, this is done using two acquisitions acquired with opposite phase-encoding directions, which results in the same field creating distortions in opposing directions.
+<code>topup</code>, part of the FSL library, estimates and attempts to correct
+the susceptibility-induced off-resonance field by using 2 (or more)
+acquisitions, where the acquisition parameters differ such that the distortion
+differs. Typically, this is done using two acquisitions acquired with opposite
+phase-encoding directions, which results in the same field creating distortions
+in opposing directions.
 
-Here, we will make use of the two opposite phase-encoded acquisitions found in the <code>fmap</code> directory of each subjet. These are acquired with a diffusion weighting of b = 0 s/mm^2. Alternatively, if these are not available, one can also extract and make use of the non-diffusion weighted images (assuming the data is also acquired with opposite phase encoding directions).
+Here, we will make use of the two opposite phase-encoded acquisitions found in
+the <code>fmap</code> directory of each subjet. These are acquired with a
+diffusion weighting of b = 0 s/mm^2. Alternatively, if these are not available,
+one can also extract and make use of the non-diffusion weighted images
+(assuming the data is also acquired with opposite phase encoding directions).
 
 First, we will merge the two files so that all of the volumes are in 1 file.
 
@@ -99,7 +138,15 @@ fslmerge -t ../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/
 ~~~
 {: .language-bash}
 
-Another file we will need to create is a text file containing the information about how the volumes were acquired. Each line in this file will pertain to a single volume in the merged file. The first 3 values of each line refers to the acquisition direction, typically along the y-axis (or anterior-posterior). The final value is the total readout time (from center of first echo to center of final echo), which can be determined from values contained within the json sidecar. Each line will look similar to <code>[x y z TotalReadoutTime]</code>. In this case, the file, which we created, is contained within the <code>pedir.txt</code> file in the derivative directory.
+Another file we will need to create is a text file containing the information
+about how the volumes were acquired. Each line in this file will pertain to a
+single volume in the merged file. The first 3 values of each line refers to the
+acquisition direction, typically along the y-axis (or anterior-posterior). The
+final value is the total readout time (from center of first echo to center of
+final echo), which can be determined from values contained within the JSON
+sidecar. Each line will look similar to <code>[x y z TotalReadoutTime]</code>.
+In this case, the file, which we created, is contained within the
+<code>pedir.txt</code> file in the derivative directory.
 
 ~~~
 0 1 0 0.04914
@@ -112,24 +159,35 @@ Another file we will need to create is a text file containing the information ab
 {: .language-bash}
 
 
-With these two inputs, the next step is to make the call to <code>topup</code> to estimate the susceptibility-induced field. Within the call, a few parameters are used. Briefly:
- * <code>--imain</code> specifies the previously merged volume
- * <code>--datain</code> specifies the text file containing the information regarding the acquisition.
- * <code>--config=b02b0.cnf</code> makes use of a predefined config file supplied with <code>topup</code>, which contains parameters useful to registering with good b=0 s/mm^2 images.
- * <code>--out</code> defines the output files containing the spline coefficients for the induced field, as well as subject movement parameters
+With these two inputs, the next step is to make the call to <code>topup</code>
+to estimate the susceptibility-induced field. Within the call, a few parameters
+are used. Briefly:
+* <code>--imain</code> specifies the previously merged volume
+* <code>--datain</code> specifies the text file containing the information
+  regarding the acquisition.
+* <code>--config=b02b0.cnf</code> makes use of a predefined config file
+  supplied with <code>topup</code>, which contains parameters useful to
+  registering with good b=0 s/mm^2 images.
+* <code>--out</code> defines the output files containing the spline
+  coefficients for the induced field, as well as subject movement parameters
 
 ~~~
 topup --imain=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/sub-010006_ses-01_acq-SEfmapDWI_epi.nii.gz --datain=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/pedir.txt --config=b02b0.cnf --out=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/topup
 ~~~
 {: .language-bash}
 
-Next, we can apply the correction to the entire diffusion weighted volume by using <code>applytopup</code> Similar to <code>topup</code>, a few parameters are used. Briefly:
+Next, we can apply the correction to the entire diffusion weighted volume by
+using <code>applytopup</code> Similar to <code>topup</code>, a few parameters
+are used. Briefly:
   * <code>--imain</code> specifies the input diffusion weighted volume
-  * <code>--datain</code> again specifies the text file containing information regarding the acquisition - same file previously used
-  * <code>--inindex</code> specifies the index (comma separated list) of the input image to be corrected
-  * <code>--topup</code> name of field/movements (from previous topup step
-  * <code>--out</code> basename for the corrected output image
-  * <code>--method</code> (optional) jacobian modulation (jac) or least-squares resampling (lsr)
+* <code>--datain</code> again specifies the text file containing information
+  regarding the acquisition - same file previously used
+* <code>--inindex</code> specifies the index (comma separated list) of the
+  input image to be corrected
+* <code>--topup</code> name of field/movements (from previous topup step
+* <code>--out</code> basename for the corrected output image
+* <code>--method</code> (optional) jacobian modulation (jac) or least-squares
+  resampling (lsr)
 
 ~~~
 applytopup --imain=../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.nii.gz --datain=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/pedir.txt --inindex=1 --topup=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/topup --out=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/dwi --method=jac
@@ -140,21 +198,39 @@ applytopup --imain=../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_d
 
 ### FSL [`Eddy`](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/eddy)
 
-Another source of the non-zero off resonance fields is caused by the rapid switching of diffusion weighting gradients, otherwise known as eddy current-induced off-resonance fields. Additionally, the subject is likely to move during the diffusion protocol, which may be lengthy.
+Another source of the non-zero off resonance fields is caused by the rapid
+switching of diffusion weighting gradients, otherwise known as eddy
+current-induced off-resonance fields. Additionally, the subject is likely to
+move during the diffusion protocol, which may be lengthy.
 
-<code>eddy</code>, also part of the FSL library, attempts to correct for both eddy current-induced fields and subject movement by reading the gradient table and estimating the distortion volume by volume. This tool is also able to optionally detect and replace outlier slices.
+<code>eddy</code>, also part of the FSL library, attempts to correct for both
+eddy current-induced fields and subject movement by reading the gradient table
+and estimating the distortion volume by volume. This tool is also able to
+optionally detect and replace outlier slices.
 
-Here, we will demonstrate the application of <code>eddy</code> following the <code>topup</code> correction step, by making use of both the uncorrected diffusion data, as well as distortion corrections from the previous step. Additionally, a text file, which maps each of the volumes to one of the corresponding acquisition directions from the <code>pedir.txt</code> file will have to be created. Finally, similar to <code>topup</code>, there are also a number of input parameters which have to be specified:
+Here, we will demonstrate the application of <code>eddy</code> following the
+<code>topup</code> correction step, by making use of both the uncorrected
+diffusion data, as well as distortion corrections from the previous step.
+Additionally, a text file, which maps each of the volumes to one of the
+corresponding acquisition directions from the <code>pedir.txt</code> file will
+have to be created. Finally, similar to <code>topup</code>, there are also a
+number of input parameters which have to be specified:
 
-  * <code>--imain</code> specifies the undistorted diffusion weighted volume
-  * <code>--mask</code> specifies the brainmask for the undistorted diffusion weighted volume
-  * <code>--acqp</code> specifies the the text file containing information regarding the acquisition that was previously used in <code>topup</code>
-  * <code>--index</code> is the text file which maps each diffusion volume to the corresponding acquisition direction
-  * <code>--bvecs</code> specifies the bvec file to the undistorted dwi
-  * <code>--bvals</code> similarily specifies the bval file to the undistorted dwi
-  * <code>--topup</code> specifies the directory and distortion correction files previously estimated by <code>topup</code>
-  * <code>--out</code> specifies the prefix of the output files following eddy correction
-  * <code>--repol</code> is a flag, which specifies replacement of outliers
+* <code>--imain</code> specifies the undistorted diffusion weighted volume
+* <code>--mask</code> specifies the brainmask for the undistorted diffusion
+  weighted volume
+* <code>--acqp</code> specifies the the text file containing information
+  regarding the acquisition that was previously used in <code>topup</code>
+* <code>--index</code> is the text file which maps each diffusion volume to the
+   corresponding acquisition direction
+* <code>--bvecs</code> specifies the bvec file to the undistorted dwi
+* <code>--bvals</code> similarily specifies the bval file to the undistorted
+  dwi
+* <code>--topup</code> specifies the directory and distortion correction files
+  previously estimated by <code>topup</code>
+* <code>--out</code> specifies the prefix of the output files following eddy
+  correction
+* <code>--repol</code> is a flag, which specifies replacement of outliers
 
 ~~~
 mkdir -p ../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/work
@@ -172,9 +248,21 @@ eddy_openmp --imain=../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_
 
 ### Registration with T1w
 
-The final step to our diffusion processing is registration to an anatomical image (eg. T1-weighted). This is important because the diffusion data, typically acquired using echo planar imaging or EPI, enables faster acquisitions at the cost of lower resolution and introduction of distortions (as seen above). Registration with the anatomical image not only helps to correct for some distortions, it also provides us with a higher resolution, anatomical reference.
+The final step to our diffusion processing is registration to an anatomical
+image (eg. T1-weighted). This is important because the diffusion data,
+typically acquired using echo planar imaging or EPI, enables faster
+acquisitions at the cost of lower resolution and introduction of distortions
+(as seen above). Registration with the anatomical image not only helps to
+correct for some distortions, it also provides us with a higher resolution,
+anatomical reference.
 
-First, we will create a brainmask of the anatomical image using the second inversion. To do this, we will use FSL <code>bet</code> twice. The first call to <code>bet</code> will create a general skullstripped brain. Upon inspection, we can note that there is still some residual areas of the image which were included in the first pass. Calling <code>bet</code> a second time, we get a better outline of the brain and brainmask, which we can use for further processing.
+First, we will create a brainmask of the anatomical image using the second
+inversion. To do this, we will use FSL <code>bet</code> twice. The first call
+to <code>bet</code> will create a general skullstripped brain. Upon inspection,
+we can note that there is still some residual areas of the image which were
+included in the first pass. Calling <code>bet</code> a second time, we get a
+better outline of the brain and brainmask, which we can use for further
+processing.
 
 ~~~
 mkdir -p ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat
@@ -188,9 +276,21 @@ mv ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006
 
 ![T1w brain mask]({{ relative_root_path }}/fig/preprocessing/T1w_brainmask.png)
 
-Note, we use <code>bet</code> here, as well as the second inversion of the anatomical image, as it provides us with a better brainmask. The <code>bet</code> command above is called to output only the binary mask and the fractional intensity threshold is also increased slightly (to 0.6) provide a smaller outline of the brain initially, and then decreased (to 0.4) to provide a larger outline. The flag <code>-m</code> indicates to the tool to create a brainmask in addition to outputting the extracted brain volume. Both the mask and brain volume will be used in our registration step.
+Note, we use <code>bet</code> here, as well as the second inversion of the
+anatomical image, as it provides us with a better brain mask. The
+<code>bet</code> command above is called to output only the binarymask and the
+fractional intensity threshold is also increased slightly (to 0.6) provide a
+smaller outline of the brain initially, and then decreased (to 0.4) to provide
+a larger outline. The flag <code>-m</code> indicates to the tool to create a
+brainmask in addition to outputting the extracted brain volume. Both the mask
+and brain volume will be used in our registration step.
 
-Before we get to the registration, we will also update our DWI brainmask by performing a brain extraction using <code>dipy</code> on the eddy corrected image. Note that the output of <code>eddy</code> is not in BIDS format so we will include the path to the diffusion data manually. We will save both the brainmask and the extracted brain volume. Additionally, we will save a separate volume of only the first b0 to use for the registration.
+Before we get to the registration, we will also update our DWI brainmask by
+performing a brain extraction using <code>dipy</code> on the eddy corrected
+image. Note that the output of <code>eddy</code> is not in BIDS format so we
+will include the path to the diffusion data manually. We will save both the
+brainmask and the extracted brain volume. Additionally, we will save a separate
+volume of only the first b0 to use for the registration.
 
 ~~~
 from dipy.segment.mask import median_otsu
@@ -223,9 +323,16 @@ nib.save(img, os.path.join(out_dir, "sub-010006_ses-01_dwi_proc-eddy_b0.nii.gz")
 ~~~
 {: .language-python}
 
-To perform the registration between the diffusion volumes and T1w, we will make use of ANTs, specifically the <code>antsRegistrationSyNQuick.sh</code> script and <code>antsApplyTransform</code>. We will begin by registering the diffusion b=0 s/mm^2 volume to get the appropriate transforms to align the two images. We will then apply the inverse transformation to the T1w volume such that it is aligned to the diffusion volume
+To perform the registration between the diffusion volumes and T1w, we will make
+use of ANTs, specifically the <code>antsRegistrationSyNQuick.sh</code> script
+and <code>antsApplyTransform</code>. We will begin by registering the diffusion
+b=0 s/mm^2 volume to get the appropriate transforms to align the two images. We
+will then apply the inverse transformation to the T1w volume such that it is
+aligned to the diffusion volume
 
-Here, we will constrain <code>antsRegistrationSyNQuick.sh</code> to perform a rigid and affine transformation (we will explain why in the final step). There are a few parameters that must be set:
+Here, we will constrain <code>antsRegistrationSyNQuick.sh</code> to perform a
+rigid and affine transformation (we will explain why in the final step). There
+are a few parameters that must be set:
 
 * <code>-d</code> - Image dimension (2/3D)
 * <code>-t</code> - Transformation type (<code>a</code> performs only rigid + affine transformation)
@@ -241,7 +348,10 @@ antsRegistrationSyNQuick.sh -d 3 -t a -f ../../data/ds000221/derivatives/uncorre
 ~~~
 {: .language-bash}
 
-The transformation file should be created which we will use to apply the inverse transform with <code>antsApplyTransform</code> to the T1w volume. Similar to the previous command, there are few parameters that will need to be set:
+The transformation file should be created which we will use to apply the
+inverse transform with <code>antsApplyTransform</code> to the T1w volume.
+Similar to the previous command, there are few parameters that will need to be
+set:
 
 * <code>-d</code> - Image dimension (2/3/4D)
 * <code>-i</code> - Input volume to be transformed (T1w)
@@ -249,7 +359,9 @@ The transformation file should be created which we will use to apply the inverse
 * <code>-t</code> - Transformation file (can be called more than once)
 * <code>-o</code> - Output volume in the transformed space.
 
-Note that if more than 1 transformation file is provided, the order in which the transforms are applied to the volume is in reverse order of how it is inputted (e.g. last transform gets applied first).
+Note that if more than 1 transformation file is provided, the order in which
+the transforms are applied to the volume is in reverse order of how it is
+inputted (e.g. last transform gets applied first).
 
 ~~~
 # Apply transform to 4D DWI volume
@@ -259,20 +371,47 @@ antsApplyTransforms -d 3 -i ../../data/ds000221/derivatives/uncorrected/sub-0100
 
 ![Transformed volumes]({{ relative_root_path }}/fig/preprocessing/transformed_volumes.png)
 
-Following the transformation of the T1w volume, we can see that anatomical and diffusion weighted volumes are now aligned. It should be highlighted that as part of the transformation step, the T1w volume is resampled based on the voxel size of the ference volume (e.g. DWI).
+Following the transformation of the T1w volume, we can see that anatomical and
+diffusion weighted volumes are now aligned. It should be highlighted that as
+part of the transformation step, the T1w volume is resampled based on the voxel
+size of the ference volume (e.g. DWI).
 
 ### Preprocessing notes:
 
-1. In this lesson, the T1w volume is registered to the DWI volume. This method minimizes the manipulation of the diffusion data. It is also possible to register the DWI volume to the T1w volume and would require the associated diffusion gradient vectors (bvec) to also be similarly rotated. If this step is not performed, one would have incorrect diffusion gradient directions relative to the registered DWI volumes. This also highlights a reason behind not performing a non-linear transformation for registration, as each individual diffusion gradient direction would also have to be subsequently warped. Rotation of the diffusion gradient vectors can be done by applying the affine transformation to each row of the file. Luckily, there are existing scripts that can do this. One such Python script was created by Michael Paquette: [<code>rot_bvecs_ants.py</code>](https://gist.github.com/mpaquette/5d59ad195778f9d984c5def42f53de6e).
+1. In this lesson, the T1w volume is registered to the DWI volume. This method
+   minimizes the manipulation of the diffusion data. It is also possible to
+   register the DWI volume to the T1w volume and would require the associated
+   diffusion gradient vectors (bvec) to also be similarly rotated. If this step
+   is not performed, one would have incorrect diffusion gradient directions
+   relative to the registered DWI volumes. This also highlights a reason behind
+   not performing a non-linear transformation for registration, as each
+   individual diffusion gradient direction would also have to be subsequently
+   warped. Rotation of the diffusion gradient vectors can be done by applying
+   the affine transformation to each row of the file. Luckily, there are
+   existing scripts that can do this. One such Python script was created by
+   Michael Paquette: [<code>rot_bvecs_ants.py</code>](https://gist.github.com/mpaquette/5d59ad195778f9d984c5def42f53de6e).
 
-2. We have only demonstrated the preprocessing steps where there is general consensus on how DWI data should be processed. There are also additional steps with certain caveats, which include denoising, unringing (to remove/minimize effects of Gibbs ringing artifacts), and gradient non-linearity correction (to unwarp distortions caused by gradient-field inhomogeneities using a vendor acquired gradient coefficient file.
+2. We have only demonstrated the preprocessing steps where there is general
+   consensus on how DWI data should be processed. There are also additional
+   steps with certain caveats, which include denoising, unringing (to
+   remove/minimize effects of Gibbs ringing artifacts), and gradient
+   non-linearity correction (to unwarp distortions caused by gradient-field
+   inhomogeneities using a vendor acquired gradient coefficient file.
 
-3. Depending on how the data is acquired, certain steps may not be possible. For example, if the data is not acquired in two directions, <code>topup</code> may not be possible (in this situation, distortion correction may be better handled by registering with a T1w anatomical image directly.
+3. Depending on how the data is acquired, certain steps may not be possible.
+   For example, if the data is not acquired in two directions,
+   <code>topup</code> may not be possible (in this situation, distortion
+   correction may be better handled by registering with a T1w anatomical image
+   directly.
 
-4. There are also a number of tools available for preprocessing. In this lesson, we demonstrate some of the more commonly used tools alongside <code>dipy</code>.
+4. There are also a number of tools available for preprocessing. In this
+   lesson, we demonstrate some of the more commonly used tools alongside
+   <code>dipy</code>.
 
 ### References
 
-.. [Cieslak2020] M. Cieslak, PA. Cook, X. He, F-C. Yeh, T. Dhollander, _et al_, "QSIPrep: An integrative platform for preprocessing and reconstructing diffusion MRI", https://doi.org/10.1101/2020.09.04.282269
+.. [Cieslak2020] M. Cieslak, PA. Cook, X. He, F-C. Yeh, T. Dhollander, _et al_,
+   "QSIPrep: An integrative platform for preprocessing and reconstructing
+   diffusion MRI", https://doi.org/10.1101/2020.09.04.282269
 
 {% include links.md %}

--- a/index.md
+++ b/index.md
@@ -16,7 +16,8 @@ image analysis.
 > MRI, scientific programming tools used throughout the lesson ([see the
 BIDS-dMRI Setup page](https://carpentries-incubator.github.io/SDC-BIDS-dMRI/setup.html)),
 and teaching experience.
-> If you are teaching this lesson in a workshop, please see the [Instructor notes](./guide/index.html).
+> If you are teaching this lesson in a workshop, please see the
+> [Instructor notes](./guide/index.html).
 {: .prereq}
 
 > ## Prerequisites for learners


### PR DESCRIPTION
Limit line length in Markdown files to 80 characters.

Fixes most of the related warnings issued by the `make lesson-check-all`
command, e.g. in
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/runs/2438761253?check_suite_focus=true#step:16:18