### PR TITLE
FIX: Update Github Actions caching

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -27,22 +27,18 @@ jobs:
       uses: actions/cache@v2
       id: cache
       with:
-        path: .cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        path: ~/.cache/pip
+        key: python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
+            python-${{ matrix.python-version }}-
 
     # Install all requirements to run these tests.
     - name: Install requirements
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
-        pip3 install virtualenv
-        virtualenv ~/sdc_bids_dmri
         pip install -r requirements.txt
         pip install pytest nbval
-        export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}`
 
     # Download the necessary data
     - name: Download data
@@ -50,14 +46,14 @@ jobs:
         pushd `pwd`
         cd ${{ github.workspace }}/data
         osf -p cmq8a fetch ds000221_subject/ds000221_sub-010006.zip
-        unzip ds000221_sub-010006.zip 
+        unzip ds000221_sub-010006.zip
         rm ds000221_sub-010006.zip
         popd
 
     # Run the actual tests of all the Python Notebooks.
     - name: Test Notebooks
       run: |
-        source ~/sdc_bids_dmri/bin/activate
+        export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}`
         pytest --nbval-lax -v code/introduction/solutions/introduction_solutions.ipynb
         pytest --nbval-lax -v code/diffusion_tensor_imaging/solutions/diffusion_tensor_imaging_solutions.ipynb
         pytest --nbval-lax -v code/constrained_spherical_deconvolution/solutions/constrained_spherical_deconvolution_solutions.ipynb

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,7 +1,8 @@
 name: Build, test
 
 on:
-  push
+  schedule:
+    - cron: "0 2 * * 1,3,5"  # 02:00 UTC every Mon,Wed,Fri
 
 jobs:
   build:
@@ -26,16 +27,19 @@ jobs:
       uses: actions/cache@v2
       id: cache
       with:
-        path: ${{ env.pythonLocation }}
-        key: python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        path: .cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-            python-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
 
     # Install all requirements to run these tests.
     - name: Install requirements
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
+        pip3 install virtualenv
+        virtualenv ~/sdc_bids_dmri
         pip install -r requirements.txt
         pip install pytest nbval
         export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}`
@@ -53,6 +57,7 @@ jobs:
     # Run the actual tests of all the Python Notebooks.
     - name: Test Notebooks
       run: |
+        source ~/sdc_bids_dmri/bin/activate
         pytest --nbval-lax -v code/introduction/solutions/introduction_solutions.ipynb
         pytest --nbval-lax -v code/diffusion_tensor_imaging/solutions/diffusion_tensor_imaging_solutions.ipynb
         pytest --nbval-lax -v code/constrained_spherical_deconvolution/solutions/constrained_spherical_deconvolution_solutions.ipynb

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,8 +1,7 @@
 name: Build, test
 
 on:
-  schedule:
-    - cron: "0 2 * * 1,3,5"  # 02:00 UTC every Mon,Wed,Fri
+  push
 
 jobs:
   build:
@@ -27,19 +26,16 @@ jobs:
       uses: actions/cache@v2
       id: cache
       with:
-        path: .cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        path: ${{ env.pythonLocation }}
+        key: python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
+            python-${{ matrix.python-version }}-
 
     # Install all requirements to run these tests.
     - name: Install requirements
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         python -m pip install --upgrade pip
-        pip3 install virtualenv
-        virtualenv ~/sdc_bids_dmri
         pip install -r requirements.txt
         pip install pytest nbval
         export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}`
@@ -57,7 +53,6 @@ jobs:
     # Run the actual tests of all the Python Notebooks.
     - name: Test Notebooks
       run: |
-        source ~/sdc_bids_dmri/bin/activate
         pytest --nbval-lax -v code/introduction/solutions/introduction_solutions.ipynb
         pytest --nbval-lax -v code/diffusion_tensor_imaging/solutions/diffusion_tensor_imaging_solutions.ipynb
         pytest --nbval-lax -v code/constrained_spherical_deconvolution/solutions/constrained_spherical_deconvolution_solutions.ipynb


### PR DESCRIPTION
I updated the "Build, test" workflow by removing the virtualenv creation step. I also set it to run only if changes are made to the `.ipynb` files

Checkout the last successful run [here](https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/runs/817037226).