### PR TITLE
FIX: Update to pip install cache

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -27,10 +27,10 @@ jobs:
       uses: actions/cache@v2
       id: cache
       with:
-        path: ~/.cache/pip
-        key: python-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        path: ${{ env.pythonLocation }}
+        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-            python-${{ matrix.python-version }}-
+            ${{ env.pythonLocation }}-
 
     # Install all requirements to run these tests.
     - name: Install requirements


### PR DESCRIPTION
I finally have this working in a separate test repository. The workflow ran successfully the first time. It re-ran a second time after a minor change to the notebook and the osf data was downloaded again. 