### PR TITLE
STYLE: Remove the unnecessary `img-responsive` class for images

### DIFF
--- a/_episodes/constrained_spherical_deconvolution.md
+++ b/_episodes/constrained_spherical_deconvolution.md
@@ -30,7 +30,7 @@ recovered as a deconvolution problem by solving a system of linear equations.
 These methods can work on both single-shell and multi-shell data.
 
 The basic equations of an SD method can be summarized as
-![Spherical deconvolution equation]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/spherical_deconvolution_equation.png){:class="img-responsive"} \
+![Spherical deconvolution equation]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/spherical_deconvolution_equation.png) \
 Spherical deconvolution
 
 There are a number of variants to the general SD framework that differ, among
@@ -187,7 +187,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![Fiber Response Function (FRF)]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/frf.png){:class="img-responsive"} \
+![Fiber Response Function (FRF)]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/frf.png) \
 Estimated response function
 
 
@@ -287,7 +287,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![CSD ODFs]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_odfs.png){:class="img-responsive"} \
+![CSD ODFs]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_odfs.png) \
 CSD ODFs.
 
 The peak directions (maxima) of the fODFs can be found from the fODFs. For this
@@ -330,7 +330,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![CSD peaks]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_peaks.png){:class="img-responsive"} \
+![CSD peaks]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_peaks.png) \
 CSD Peaks.
 
 We can finally visualize both the fODFs and peaks in the same space.
@@ -348,7 +348,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![CSD peaks and fODFs]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_peaks_fodfs.png){:class="img-responsive"} \
+![CSD peaks and fODFs]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/csd_peaks_fodfs.png) \
 CSD Peaks and ODFs.
 
 
@@ -455,7 +455,7 @@ References
 > > ~~~
 > > {: .language-python}
 > > 
-> > ![ODFs of differing crossing angles]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/odf_multiple_angles.png){:class="img-responsive"} \
+> > ![ODFs of differing crossing angles]({{ relative_root_path }}/fig/constrained_spherical_deconvolution/odf_multiple_angles.png) \
 ODFs of different crossing angles.
 > >
 > {: .solution}

--- a/_episodes/deterministic_tractography.md
+++ b/_episodes/deterministic_tractography.md
@@ -107,7 +107,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![FA]({{ relative_root_path }}/fig/deterministic_tractography/fa.png){:class="img-responsive"}
+![FA]({{ relative_root_path }}/fig/deterministic_tractography/fa.png)
 
 One of the inputs of `EuDX` is the discretized voxel directions on a unit
 sphere. Therefore, it is necessary to discretize the eigenvectors before
@@ -228,7 +228,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![EuDX Determinsitic Tractography]({{ relative_root_path }}/fig/deterministic_tractography/tractogram_deterministic_EuDX.png){:class="img-responsive"}
+![EuDX Determinsitic Tractography]({{ relative_root_path }}/fig/deterministic_tractography/tractogram_deterministic_EuDX.png)
 
 > ## Exercise 1
 > 
@@ -318,7 +318,7 @@ streamlines_actor = actor.line(streamlines, colormap.line_colors(streamlines))
 > > plt.show()
 > > ~~~
 > > {: .language-python}
-> > ![Binary Stopping Criterion Tractography]({{ relative_root_path }}/fig/deterministic_tractography/tractogram_deterministic_ex1.png){:class="img-responsive"}
+> > ![Binary Stopping Criterion Tractography]({{ relative_root_path }}/fig/deterministic_tractography/tractogram_deterministic_ex1.png)
 > {: .solution}
 > 
 > ## Exercise 2
@@ -346,7 +346,7 @@ streamlines_actor = actor.line(streamlines, colormap.line_colors(streamlines))
 > > ~~~
 > > {: .language-python}
 > >
-> > ![FA Mapped Tractography]({{ relative_root_path }}/fig/deterministic_tractography/tractogram_deterministic_fa.png){:class="img-responsive"}
+> > ![FA Mapped Tractography]({{ relative_root_path }}/fig/deterministic_tractography/tractogram_deterministic_fa.png)
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -27,7 +27,7 @@ The DTI model is still a commonly used model to investigate white matter.
 
 The tensor models the diffusion signal mathematically as:
 
-![Diffusion signal equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/diffusion_eqn.png){:class="img-responsive"}
+![Diffusion signal equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/diffusion_eqn.png)
 
 Where ![Diffusion unit vector]({{ relative_root_path }}/fig/diffusion_tensor_imaging/inline_unitvector.png) 
 is a unit vector in 3D space indicating the direction of measurement and b are the parameters of 
@@ -40,7 +40,7 @@ is the signal conducted in a measurement with no diffusion weighting.
 is a positive-definite quadratic form, which contains six free parameters to be fit. 
 These six parameters are:
 
-![Diffusivity matrix]({{ relative_root_path }}/fig/diffusion_tensor_imaging/diffusion_matrix.png){:class="img-responsive"}
+![Diffusivity matrix]({{ relative_root_path }}/fig/diffusion_tensor_imaging/diffusion_matrix.png)
 
 The diffusion matrix is a variance-covariance matrix of the diffusivity along the three spatial 
 dimensions. Note that we can assume that the diffusivity has antipodal symmetry, so elements 
@@ -58,7 +58,7 @@ Eigenvalues are always strictly positive in the context of dMRI and are measured
 In the DTI model, the largest eigenvalue gives the principal direction of the diffusion tensor, 
 and the other two eigenvectors span the orthogonal plane to the former direction.
 
-![Diffusion tensor]({{ relative_root_path }}/fig/diffusion_tensor_imaging/DiffusionTensor.png){:class="img-responsive"}
+![Diffusion tensor]({{ relative_root_path }}/fig/diffusion_tensor_imaging/DiffusionTensor.png)
 _Adapted from Jelison et al., 2004_
 
 In the following example, we will walk through how to model a diffusion dataset. While there 
@@ -160,7 +160,7 @@ a particular direction.
 
 Mathematically, FA is defined as the normalized variance of the eigenvalues of the tensor:
 
-![FA equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/fa_eqn.png){:class="img-responsive"}
+![FA equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/fa_eqn.png)
 
 Values of FA vary between 0 and 1 (unitless). In the cases of perfect, isotropic diffusion, 
 ![Isotropic diffusion eigenvalues]({{ relative_root_path }}/fig/diffusion_tensor_imaging/fa_iso.png), 
@@ -187,7 +187,7 @@ plot.plot_anat(fa_img)
 ~~~
 {: .language-python}
 
-![FA plot]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_fa.png){:class="img-responsive"}
+![FA plot]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_fa.png)
 
 Derived from partial volume effects in imaging voxels due to the presence of different tissues, 
 noise in the measurements and numerical errors, the DTI model estimation may yield negative 
@@ -209,7 +209,7 @@ degree of diffusion, independent of direction. This is sometimes known as the ap
 coefficient (ADC). Mathematically, MD is computed as the mean eigenvalues of the tensor and 
 is measured in mm^2/s.
 
-![MD equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/md_eqn.png){:class="img-responsive"}
+![MD equation]({{ relative_root_path }}/fig/diffusion_tensor_imaging/md_eqn.png)
 
 Similar to the previous FA image, let's take a look at what the MD map looks like. Again, higher 
 intensities reflect higher mean diffusivity!
@@ -221,7 +221,7 @@ plot.plot_anat(md_img, cut_coords=(0, -29, 20), vmin=0, vmax=0.01)
 ~~~
 {: .language-python}
 
-![MD plot]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_md.png){:class="img-responsive"}
+![MD plot]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_md.png)
 
 
 ### Axial and radial diffusivity (AD & RD)
@@ -237,7 +237,7 @@ On the other hand, RD reflects the average diffusivity along the other two minor
 (![Radial diffusivity eigenvalues]({{ relative_root_path }}/fig/diffusion_tensor_imaging/minor_axes.png))
 . Both are measured in mm^2/s.
 
-![Axial and radial diffusivities]({{ relative_root_path }}/fig/diffusion_tensor_imaging/ax_rad_diff.png){:class="img-responsive"}
+![Axial and radial diffusivities]({{ relative_root_path }}/fig/diffusion_tensor_imaging/ax_rad_diff.png)
 
 
 ### Tensor visualizations
@@ -269,7 +269,7 @@ ax[2].imshow(ndimage.rotate(RGB_map[:, :, RGB_map.shape[2]//2, :], 90, reshape=F
 ~~~
 {: .language-python}
 
-![RGB FA map]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_fa_rgb.png){:class="img-responsive"}
+![RGB FA map]({{ relative_root_path }}/fig/diffusion_tensor_imaging/plot_fa_rgb.png)
 
 Another way of visualizing the tensors is to display the diffusion tensor in each imaging voxel 
 with colour encoding 
@@ -277,7 +277,7 @@ with colour encoding
 the necessary steps to perform this type of visualization, as it can be memory intensive). 
 Below is an example of one such tensor visualization.
 
-![Tensor visualization]({{ relative_root_path }}/fig/diffusion_tensor_imaging/TensorViz.png){:class="img-responsive"}
+![Tensor visualization]({{ relative_root_path }}/fig/diffusion_tensor_imaging/TensorViz.png)
 
 
 ### Some notes on DTI
@@ -286,7 +286,7 @@ DTI is only one of many models and is one of the simplest models available for m
 diffusion. While it is used for many studies, there are also some drawbacks (e.g. ability to 
 distinguish multiple fibre orientations in an imaging voxel). Examples of this can be seen below!
 
-![DTI drawbacks]({{ relative_root_path }}/fig/diffusion_tensor_imaging/FiberConfigurations.png){:class="img-responsive"}
+![DTI drawbacks]({{ relative_root_path }}/fig/diffusion_tensor_imaging/FiberConfigurations.png)
 
 _Sourced from Sotiropoulos and Zalesky (2017). Building connectomes using diffusion MRI: 
 why, how, and but. NMR in Biomedicine. 4(32). e3752. doi:10.1002/nbm.3752._

--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -32,7 +32,7 @@ lesson), the acquired images can provide measurements which are related to the
 microscopic changes and estimate white matter trajectories. Images with no
 diffusion weighting are also acquired as part of the acquisition protocol.
 
-![Diffusion along X, Y, and Z directions]({{ relative_root_path }}/fig/introduction/DiffusionDirections.png){:class="img-responsive"} \
+![Diffusion along X, Y, and Z directions]({{ relative_root_path }}/fig/introduction/DiffusionDirections.png) \
 Diffusion along X, Y, and Z directions
 
 ## b-values & b-vectors
@@ -231,7 +231,7 @@ for i, slice in enumerate(slices):
 ~~~
 {: .language-python}
 
-![DWI slice]({{ relative_root_path }}/fig/introduction/dwi_slice.png){:class="img-responsive"}
+![DWI slice]({{ relative_root_path }}/fig/introduction/dwi_slice.png)
 
 We can also see how the diffusion gradients are represented. This is plotted on
 a sphere, the further away from the center of the sphere, the stronger the
@@ -246,7 +246,7 @@ ax.scatter(bvec_txt[0], bvec_txt[1], bvec_txt[2])
 ~~~
 {: .language-python}
 
-![Diffusion gradient sphere]({{ relative_root_path }}/fig/introduction/diffusion_gradient.png){:class="img-responsive"}
+![Diffusion gradient sphere]({{ relative_root_path }}/fig/introduction/diffusion_gradient.png)
 
 The files associated with the diffusion gradients need to converted to a
 <code>GradientTable</code> object to be used with <code>Dipy</code>. A

--- a/_episodes/local_tractography.md
+++ b/_episodes/local_tractography.md
@@ -25,7 +25,7 @@ Streamline propagation is, in essence, a numerical analysis integration
 problem. The problem lies in finding a curve that joins a set of discrete local
 directions. As such, it takes the form of a differential equation problem of
 the form:
-![Streamline propagation equation]({{ relative_root_path }}/fig/local_tractography/streamline_propagation_diff_equation.png){:class="img-responsive"} \
+![Streamline propagation equation]({{ relative_root_path }}/fig/local_tractography/streamline_propagation_diff_equation.png) \
 Streamline propagation differential equation
 
 where the curve $r(s)$ needs to be solved for.

--- a/_episodes/probabilistic_tractography.md
+++ b/_episodes/probabilistic_tractography.md
@@ -162,7 +162,7 @@ would result in streamlines being unable to propagate to other white matter
 areas). Visually inspecting the GFA map might provide with a sufficient
 guarantee about the goodness of the value.
 
-![GFA]({{ relative_root_path }}/fig/probabilistic_tractography/gfa.png){:class="img-responsive"} \
+![GFA]({{ relative_root_path }}/fig/probabilistic_tractography/gfa.png) \
 GFA
 
 The Fiber Orientation Distribution (FOD) of the CSD model estimates the
@@ -212,7 +212,7 @@ the `generate_anatomical_volume_figure` helper function:
 
 ~~~
 from fury import actor, colormap
-
+r
 from utils.visualization_utils import generate_anatomical_volume_figure
 
 # Plot the tractogram
@@ -229,7 +229,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![PMF direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_pmf.png){:class="img-responsive"} \
+![PMF direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_pmf.png) \
 Streamlines representing white matter using probabilistic direction getter from
 PMF
 
@@ -279,7 +279,7 @@ plt.show()
 {: .language-python}
 
 
-![SH direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_sh.png){:class="img-responsive"} \
+![SH direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_sh.png) \
 Streamlines representing white matter using probabilistic direction getter from
 SH
 
@@ -328,7 +328,7 @@ plt.show()
 ~~~
 {: .language-python}
 
-![CSD model peaks for tracking]({{ relative_root_path }}/fig/probabilistic_tractography/peaks.png){:class="img-responsive"} \
+![CSD model peaks for tracking]({{ relative_root_path }}/fig/probabilistic_tractography/peaks.png) \
 Peaks obtained from the CSD model for tracking purposes
 
 We will now perform the tracking process using the local orientation
@@ -367,7 +367,7 @@ plt.show()
 {: .language-python}
 
 
-![PMF SH direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_sh_pmf.png){:class="img-responsive"} \
+![PMF SH direction getter-derived probabilistic tractogram]({{ relative_root_path }}/fig/probabilistic_tractography/tractogram_probabilistic_dg_sh_pmf.png) \
 Streamlines representing white matter using probabilistic direction getter from
 SH (peaks_from_model)
 

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -27,7 +27,7 @@ the coronal plane.
 - **yaw** (vertical axis): an axis running bottom to top, allowing rotations in
 the axial plane.
 
-![Camera Orientations]({{ relative_root_path }}/fig/discuss/camera_viewpoint_concepts_anatomy.png){:class="img-responsive"} \
+![Camera Orientations]({{ relative_root_path }}/fig/discuss/camera_viewpoint_concepts_anatomy.png) \
 Camera axis orientations
 
 We can visualize the different axis with reference to neuroanatomy and the rotations around them.


### PR DESCRIPTION
Remove the unnecessary `img-responsive` class for images: rely on the
`Carpentries` `lesson.scss` `img` class to handle the necessary properties.