### PR TITLE
BUG: Fix data location in non solution introduction notebook

### DIFF
--- a/code/introduction/introduction.ipynb
+++ b/code/introduction/introduction.ipynb
@@ -124,7 +124,7 @@
     "\n",
     "bids.config.set_option('extension_initial_dot', True)\n",
     "\n",
-    "layout = BIDSLayout(\"../../../data/ds000221\", validate=False)"
+    "layout = BIDSLayout(\"../../data/ds000221\", validate=False)"
    ]
   },
   {

--- a/code/introduction/solutions/introduction_solutions.ipynb
+++ b/code/introduction/solutions/introduction_solutions.ipynb
@@ -40,10 +40,10 @@
    "source": [
     "Below is a tree diagram showing the folder structure of a single MR subject and session within ds000221. This was obtained by using the bash command `tree`.\n",
     "\n",
-    "`!tree ../../data/ds000221`\n",
+    "`!tree ../../../data/ds000221`\n",
     "\n",
     "```\n",
-    "../../data/ds000221\n",
+    "../../../data/ds000221\n",
     "├── .bidsignore\n",
     "├── CHANGES\n",
     "├── dataset_description.json\n",


### PR DESCRIPTION
Fix data location in non solution introduction notebook.

Fixes:
```
(...)
----> 8 layout = BIDSLayout("../../../data/ds000221", validate=False)
(...)
     67     if not os.path.exists(root):
---> 68         raise ValueError("BIDS root does not exist: %s" % root)
(...)
ValueError: BIDS root does not exist: /home/runner/work/SDC-BIDS-dMRI/data/ds000221
```

reported in:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/runs/3120044369?check_suite_focus=true#step:7:72