### PR TITLE
ENH: Skip visualization cells in non-solution CSD notebook

### DIFF
--- a/code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb
+++ b/code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb
@@ -178,6 +178,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "from dipy.sims.voxel import single_tensor_odf\n",
     "from fury import window, actor\n",
@@ -210,6 +212,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
+    "\n",
     "scene.rm(response_actor)"
    ]
   },
@@ -316,6 +320,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
+    "\n",
     "from utils.visualization_utils import generate_anatomical_slice_figure\n",
     "\n",
     "colormap = \"plasma\"\n",
@@ -381,6 +387,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
+    "\n",
     "# Build the representation of the data\n",
     "peaks_actor = actor.peak_slicer(csd_peaks.peak_dirs, csd_peaks.peak_values)\n",
     "\n",
@@ -405,6 +413,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# NBVAL_SKIP\n",
+    "\n",
     "fodf_actor.GetProperty().SetOpacity(0.4)\n",
     "\n",
     "# Generate the figure\n",


### PR DESCRIPTION
Skip visualization cells in non-solution CSD notebook.

Fixes:
```
_ code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb::Cell 4 _
Notebook cell execution failed
Cell 4: Timeout of 2000 seconds exceeded while executing cell. Failed to interrupt kernel in 5 seconds, so failing without traceback.
```

reported in:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/runs/3140013883?check_suite_focus=true#step:7:109