### PR TITLE
ENH: Update `DIPY` fiber response function method call

### DIFF
--- a/_episodes/constrained_spherical_deconvolution.md
+++ b/_episodes/constrained_spherical_deconvolution.md
@@ -100,15 +100,22 @@ single coherent fiber populations. This is determined by checking the
 Fractional Anisotropy (FA) derived from the DTI model.
 
 For example, if we use an ROI at the center of the brain, we will
-find single fibers from the corpus callosum. `DIPY`'s `auto_response` function
-will calculate FA for an ROI of radius equal to `roi_radius` in the center
-of the volume and return the response function estimated in that region for
-the voxels with FA higher than a given threshold.
+find single fibers from the corpus callosum. `DIPY`'s `auto_response_ssst`
+function will calculate the FA for an ROI of radius equal to `roi_radii` in
+the center of the volume, and return the response function estimated in that
+region for the voxels with FA higher than a given threshold.
+
+> ## The fiber response function and the diffusion model
+> The `auto_response_ssst` method is relevant within a Single-Shell
+> Single-Tissue (SSST) context/model; e.g. Multi-Shell Multi-Tissue (MSMT)
+> context/models require the fiber response
+> function to be computed differently.
+{: .callout}
 
 ~~~
-from dipy.reconst.csdeconv import auto_response
+from dipy.reconst.csdeconv import auto_response_ssst
 
-response, ratio = auto_response(gtab, data, roi_radius=10, fa_thr=0.7)
+response, ratio = auto_response_ssst(gtab, data, roi_radii=10, fa_thr=0.7)
 
 # Create the directory to save the results
 out_dir = '../../data/ds000221/derivatives/dwi/reconstruction/sub-%s/ses-01/dwi/' % subj

--- a/_episodes/probabilistic_tractography.md
+++ b/_episodes/probabilistic_tractography.md
@@ -57,7 +57,7 @@ from dipy.core.gradients import gradient_table
 from dipy.data import get_fnames
 from dipy.io.gradients import read_bvals_bvecs
 from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,
-                                   auto_response)
+                                   auto_response_ssst)
 from dipy.tracking import utils
 from dipy.tracking.local_tracking import LocalTracking
 from dipy.tracking.streamline import Streamlines
@@ -110,7 +110,7 @@ We will now estimate the FRF and set the CSD model to feed the local orientation
 information to the streamline propagation object:
 
 ~~~
-response, ratio = auto_response(gtab, dwi_data, roi_radius=10, fa_thr=0.7)
+response, ratio = auto_response_ssst(gtab, dwi_data, roi_radii=10, fa_thr=0.7)
 sh_order = 2
 csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=sh_order)
 csd_fit = csd_model.fit(dwi_data, mask=seed_mask)

--- a/code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb
+++ b/code/constrained_spherical_deconvolution/constrained_spherical_deconvolution.ipynb
@@ -93,10 +93,15 @@
     "Anisotropy (FA) derived from the DTI model.\n",
     "\n",
     "For example, if we use an ROI at the center of the brain, we will\n",
-    "find single fibers from the corpus callosum. `DIPY`'s `auto_response` function\n",
-    "will calculate FA for an ROI of radius equal to `roi_radius` in the center\n",
-    "of the volume and return the response function estimated in that region for\n",
-    "the voxels with FA higher than a given threshold."
+    "find single fibers from the corpus callosum. `DIPY`'s `auto_response_ssst`\n",
+    "function will calculate the FA for an ROI of radius equal to `roi_radii` in\n",
+    "the center of the volume, and return the response function estimated in that\n",
+    "region for the voxels with FA higher than a given threshold.\n",
+    "\n",
+    "_Note: the `auto_response_ssst` method is relevant within a Single-Shell\n",
+    "Single-Tissue (SSST) context/model; e.g. Multi-Shell Multi-Tissue (MSMT)\n",
+    "context/models require the fiber response\n",
+    "function to be computed differently._ "
    ]
   },
   {
@@ -105,9 +110,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from dipy.reconst.csdeconv import auto_response\n",
+    "from dipy.reconst.csdeconv import auto_response_ssst\n",
     "\n",
-    "response, ratio = auto_response(gtab, data, roi_radius=10, fa_thr=0.7)\n",
+    "response, ratio = auto_response_ssst(gtab, data, roi_radii=10, fa_thr=0.7)\n",
     "\n",
     "# Create the directory to save the results\n",
     "out_dir = '../../data/ds000221/derivatives/dwi/reconstruction/sub-%s/ses-01/dwi/' % subj\n",

--- a/code/constrained_spherical_deconvolution/solutions/constrained_spherical_deconvolution_solutions.ipynb
+++ b/code/constrained_spherical_deconvolution/solutions/constrained_spherical_deconvolution_solutions.ipynb
@@ -102,10 +102,15 @@
     "Anisotropy (FA) derived from the DTI model.\n",
     "\n",
     "For example, if we use an ROI at the center of the brain, we will\n",
-    "find single fibers from the corpus callosum. `DIPY`'s `auto_response` function\n",
-    "will calculate FA for an ROI of radius equal to `roi_radius` in the center\n",
-    "of the volume and return the response function estimated in that region for\n",
-    "the voxels with FA higher than a given threshold."
+    "find single fibers from the corpus callosum. `DIPY`'s `auto_response_ssst`\n",
+    "function will calculate the FA for an ROI of radius equal to `roi_radii` in\n",
+    "the center of the volume, and return the response function estimated in that\n",
+    "region for the voxels with FA higher than a given threshold.\n",
+    "\n",
+    "_Note: the `auto_response_ssst` method is relevant within a Single-Shell\n",
+    "Single-Tissue (SSST) context/model; e.g. Multi-Shell Multi-Tissue (MSMT)\n",
+    "context/models require the fiber response\n",
+    "function to be computed differently._"
    ]
   },
   {
@@ -126,9 +131,9 @@
     }
    ],
    "source": [
-    "from dipy.reconst.csdeconv import auto_response\n",
+    "from dipy.reconst.csdeconv import auto_response_ssst\n",
     "\n",
-    "response, ratio = auto_response(gtab, data, roi_radius=10, fa_thr=0.7)\n",
+    "response, ratio = auto_response_ssst(gtab, data, roi_radii=10, fa_thr=0.7)\n",
     "\n",
     "# Create the directory to save the results\n",
     "out_dir = '../../../data/ds000221/derivatives/dwi/reconstruction/sub-%s/ses-01/dwi/' % subj\n",

--- a/code/probabilistic_tractography/probabilistic_tractography.ipynb
+++ b/code/probabilistic_tractography/probabilistic_tractography.ipynb
@@ -59,7 +59,7 @@
     "from dipy.core.gradients import gradient_table\n",
     "from dipy.io.gradients import read_bvals_bvecs\n",
     "from dipy.reconst.csdeconv import (ConstrainedSphericalDeconvModel,\n",
-    "                                   auto_response)\n",
+    "                                   auto_response_ssst)\n",
     "from dipy.tracking import utils\n",
     "from dipy.tracking.local_tracking import LocalTracking\n",
     "from dipy.tracking.streamline import Streamlines\n",
@@ -156,7 +156,7 @@
     }
    ],
    "source": [
-    "response, ratio = auto_response(gtab, dwi_data, roi_radius=10, fa_thr=0.7)\n",
+    "response, ratio = auto_response_ssst(gtab, dwi_data, roi_radius=10, fa_thr=0.7)\n",
     "sh_order = 2\n",
     "csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=sh_order)\n",
     "csd_fit = csd_model.fit(dwi_data, mask=seed_mask)"


### PR DESCRIPTION
Update `DIPY` fiber response function method call.

Fixes:
```
 DeprecationWarning: dipy.reconst.csdeconv.auto_response is deprecated,
Please use dipy.reconst.csdeconv.auto_response_ssst instead

* deprecated from version: 1.2
* Will raise <class 'dipy.utils.deprecator.ExpiredDeprecationError'> as of version: 1.4
  response, ratio = auto_response(gtab, data, roi_radius=10, fa_thr=0.7)
/python3.8/site-packages/dipy/reconst/csdeconv.py:80:
UserWarning: Parameter `roi_radius` is now called `roi_radii` and can be an
    array-like (3,). Parameters `fa_callable` and `return_number_of_voxels`
    are not used anymore.
  warnings.warn(msg, UserWarning)
```

Improve the explanation on the use of the method.