### PR TITLE
BUG: Fix `DIPY` fiber response function method call parameter

### DIFF
--- a/code/probabilistic_tractography/probabilistic_tractography.ipynb
+++ b/code/probabilistic_tractography/probabilistic_tractography.ipynb
@@ -159,7 +159,7 @@
     }
    ],
    "source": [
-    "response, ratio = auto_response_ssst(gtab, dwi_data, roi_radius=10, fa_thr=0.7)\n",
+    "response, ratio = auto_response_ssst(gtab, dwi_data, roi_radii=10, fa_thr=0.7)\n",
     "sh_order = 2\n",
     "csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=sh_order)\n",
     "csd_fit = csd_model.fit(dwi_data, mask=seed_mask)"


### PR DESCRIPTION
Fix `DIPY` fiber response function method call parameter.

Fixes:
```
 TypeError                                 Traceback (most recent call last)
/tmp/ipykernel_2383/1570612591.py in <module>
----> 1 response, ratio = auto_response_ssst(gtab, dwi_data, roi_radius=10, fa_thr=0.7)
      2 sh_order = 2
      3 csd_model = ConstrainedSphericalDeconvModel(gtab, response, sh_order=sh_order)
      4 csd_fit = csd_model.fit(dwi_data, mask=seed_mask)

TypeError: auto_response_ssst() got an unexpected keyword argument 'roi_radius'
```

raised in
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/runs/3209541907?check_suite_focus=true#step:7:219