### PR TITLE
BUG: Fix data paths in preprocessing episode solutions notebook

### DIFF
--- a/code/preprocessing/solutions/preprocessing_solutions.ipynb
+++ b/code/preprocessing/solutions/preprocessing_solutions.ipynb
@@ -46,7 +46,7 @@
    "source": [
     "from bids.layout import BIDSLayout\n",
     "\n",
-    "layout = BIDSLayout(\"../../data/ds000221\", validate=False)\n",
+    "layout = BIDSLayout(\"../../../data/ds000221\", validate=False)\n",
     "\n",
     "subj='010006'\n",
     "\n",
@@ -103,7 +103,7 @@
     "dwi_brain, dwi_mask = median_otsu(dwi_data, vol_idx=[0])\n",
     "\n",
     "# Create necessary folders to save mask\n",
-    "out_dir = '../../data/ds000221/derivatives/uncorrected/sub-%s/ses-01/dwi/' % subj\n",
+    "out_dir = '../../../data/ds000221/derivatives/uncorrected/sub-%s/ses-01/dwi/' % subj\n",
     "\n",
     "# Check to see if directory exists, if not create one\n",
     "if not os.path.exists(out_dir):\n",
@@ -191,7 +191,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "topup --imain=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/sub-010006_ses-01_acq-SEfmapDWI_epi.nii.gz --datain=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/pedir.txt --config=b02b0.cnf --out=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/topup"
+    "topup --imain=../../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/sub-010006_ses-01_acq-SEfmapDWI_epi.nii.gz --datain=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/pedir.txt --config=b02b0.cnf --out=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/topup"
    ]
   },
   {
@@ -215,7 +215,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "applytopup --imain=../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.nii.gz --datain=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/pedir.txt --inindex=1 --topup=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/topup --out=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/dwi --method=jac"
+    "applytopup --imain=../../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.nii.gz --datain=../../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/pedir.txt --inindex=1 --topup=../../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/topup --out=../../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/dwi --method=jac"
    ]
   },
   {
@@ -256,16 +256,16 @@
    "source": [
     "%%bash\n",
     "\n",
-    "mkdir -p ../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/work\n",
+    "mkdir -p ../../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/work\n",
     "\n",
     "# Create an index file mapping the 67 volumes in 4D dwi volume to the pedir.txt file\n",
     "indx=\"\"\n",
     "for i in `seq 1 67`; do \n",
     "  indx=\"$indx 1\"\n",
     "done\n",
-    "echo $indx > ../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/work/index.txt\n",
+    "echo $indx > ../../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/work/index.txt\n",
     "\n",
-    "eddy_openmp --imain=../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.nii.gz --mask=../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/dwi/sub-010006_ses-01_brainmask.nii.gz --acqp=../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/pedir.txt --index=../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/work/index.txt --bvecs=../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.bvec --bvals=../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.bval --topup=../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/topup --out=../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/dwi --repol"
+    "eddy_openmp --imain=../../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.nii.gz --mask=../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/dwi/sub-010006_ses-01_brainmask.nii.gz --acqp=../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/pedir.txt --index=../../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/work/index.txt --bvecs=../../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.bvec --bvals=../../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.bval --topup=../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/topup --out=../../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/dwi --repol"
    ]
   },
   {
@@ -329,12 +329,12 @@
    "source": [
     "%%bash\n",
     "\n",
-    "mkdir -p ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat\n",
+    "mkdir -p ../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat\n",
     "\n",
-    "bet ../../data/ds000221/sub-010006/ses-01/anat/sub-010006_ses-01_inv-2_mp2rage.nii.gz ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_broadbrain -f 0.6\n",
-    "bet ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_broadbrain ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brain -f 0.4 -m\n",
+    "bet ../../../data/ds000221/sub-010006/ses-01/anat/sub-010006_ses-01_inv-2_mp2rage.nii.gz ../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_broadbrain -f 0.6\n",
+    "bet ../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_broadbrain ../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brain -f 0.4 -m\n",
     "\n",
-    "mv ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brain_mask.nii.gz ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brainmask.nii.gz"
+    "mv ../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brain_mask.nii.gz ../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brainmask.nii.gz"
    ]
   },
   {
@@ -362,7 +362,7 @@
     "from dipy.segment.mask import median_otsu\n",
     "\n",
     "# Path of FSL eddy-corrected dwi\n",
-    "dwi = \"../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/dwi.nii.gz\"\n",
+    "dwi = \"../../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/dwi.nii.gz\"\n",
     "\n",
     "# Load eddy-corrected diffusion data\n",
     "dwi = nib.load(dwi)\n",
@@ -373,7 +373,7 @@
     "dwi_b0 = dwi_brain[:,:,:,0]\n",
     "\n",
     "# Output directory\n",
-    "out_dir=\"../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi\"\n",
+    "out_dir=\"../../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi\"\n",
     "\n",
     "# Save diffusion mask\n",
     "img = nib.Nifti1Image(dwi_mask.astype(np.float32), dwi_affine)\n",
@@ -411,10 +411,10 @@
    "source": [
     "%%bash\n",
     "\n",
-    "mkdir -p ../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/sub-010006/ses-01/transforms\n",
+    "mkdir -p ../../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/sub-010006/ses-01/transforms\n",
     "\n",
     "# Perform registration between b0 and T1w\n",
-    "antsRegistrationSyNQuick.sh -d 3 -t a -f ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brain.nii.gz -m ../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi_proc-eddy_b0.nii.gz -o ../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/sub-010006/ses-01/transform/dwi_to_t1_"
+    "antsRegistrationSyNQuick.sh -d 3 -t a -f ../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brain.nii.gz -m ../../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi_proc-eddy_b0.nii.gz -o ../../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/sub-010006/ses-01/transform/dwi_to_t1_"
    ]
   },
   {
@@ -441,7 +441,7 @@
     "%%bash\n",
     "\n",
     "# Apply transform to 4D DWI volume\n",
-    "antsApplyTransforms -d 3 -i ../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brain.nii.gz -r ../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi_proc-eddy_b0.nii.gz -t [../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/sub-010006/ses-01/transform/dwi_to_t1_0GenericAffine.mat,1] -o ../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/sub-010006/ses-01/anat/sub-010006_ses-01_space-dwi_T1w_brain.nii.gz"
+    "antsApplyTransforms -d 3 -i ../../../data/ds000221/derivatives/uncorrected/sub-010006/ses-01/anat/sub-010006_ses-01_space-T1w_brain.nii.gz -r ../../../data/ds000221/derivatives/uncorrected_topup_eddy/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi_proc-eddy_b0.nii.gz -t [../../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/sub-010006/ses-01/transform/dwi_to_t1_0GenericAffine.mat,1] -o ../../../data/ds000221/derivatives/uncorrected_topup_eddy_regT1/sub-010006/ses-01/anat/sub-010006_ses-01_space-dwi_T1w_brain.nii.gz"
    ]
   },
   {


### PR DESCRIPTION
Fix data paths in preprocessing episode solutions notebook.

Fixes:
```
 ----> 3 layout = BIDSLayout("../../data/ds000221", validate=False)
ValueError: BIDS root does not exist: /home/runner/work/SDC-BIDS-dMRI/SDC-BIDS-dMRI/code/data/ds000221
```

reported in:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/runs/3251572017?check_suite_focus=true#step:13:120