### PR TITLE
BUG: Fix data paths in preprocessing episode solutions notebook

### DIFF
--- a/code/preprocessing/solutions/preprocessing_solutions.ipynb
+++ b/code/preprocessing/solutions/preprocessing_solutions.ipynb
@@ -143,7 +143,7 @@
     "\n",
     "mkdir -p ../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work\n",
     "\n",
-    "fslmerge -t ../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/sub-010006_ses-01_acq-SEfmapDWI_epi.nii.gz ../../data/ds000221/sub-010006/ses-01/fmap/sub-010006_ses-01_acq-SEfmapDWI_dir-AP_epi.nii.gz ../../data/ds000221/sub-010006/ses-01/fmap/sub-010006_ses-01_acq-SEfmapDWI_dir-PA_epi.nii.gz"
+    "fslmerge -t ../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/sub-010006_ses-01_acq-SEfmapDWI_epi.nii.gz ../../../data/ds000221/sub-010006/ses-01/fmap/sub-010006_ses-01_acq-SEfmapDWI_dir-AP_epi.nii.gz ../../../data/ds000221/sub-010006/ses-01/fmap/sub-010006_ses-01_acq-SEfmapDWI_dir-PA_epi.nii.gz"
    ],
    "outputs": [
     {
@@ -189,7 +189,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "topup --imain=../../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/sub-010006_ses-01_acq-SEfmapDWI_epi.nii.gz --datain=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/pedir.txt --config=b02b0.cnf --out=../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/topup"
+    "topup --imain=../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/sub-010006_ses-01_acq-SEfmapDWI_epi.nii.gz --datain=../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/pedir.txt --config=b02b0.cnf --out=../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/topup"
    ],
    "outputs": [],
    "metadata": {}
@@ -213,7 +213,7 @@
    "source": [
     "%%bash\n",
     "\n",
-    "applytopup --imain=../../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.nii.gz --datain=../../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/pedir.txt --inindex=1 --topup=../../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/work/topup --out=../../../data/ds000221/derivatives/topup/sub-010006/ses-01/dwi/dwi --method=jac"
+    "applytopup --imain=../../../data/ds000221/sub-010006/ses-01/dwi/sub-010006_ses-01_dwi.nii.gz --datain=../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/pedir.txt --inindex=1 --topup=../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/topup --out=../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/dwi --method=jac"
    ],
    "outputs": [],
    "metadata": {}


### PR DESCRIPTION
Fix data paths in preprocessing episode solutions notebook.

Fixes:
```
=================================== FAILURES ===================================
______ code/preprocessing/solutions/preprocessing_solutions.ipynb::Cell 3 ______
Notebook cell execution failed
Cell 3: Cell execution caused an exception

CalledProcessError: Command 'b'\n
mkdir -p
../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work\n\n
fslmerge -t
../../../data/ds000221/derivatives/uncorrected_topup/sub-010006/ses-01/dwi/work/sub-010006_ses-01_acq-SEfmapDWI_epi.nii.gz
../../data/ds000221/sub-010006/ses-01/fmap/sub-010006_ses-01_acq-SEfmapDWI_dir-AP_epi.nii.gz
../../data/ds000221/sub-010006/ses-01/fmap/sub-010006_ses-01_acq-SEfmapDWI_dir-PA_epi.nii.gz\n''
 returned non-zero exit status 134.
```

reported in:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/runs/3253339903?check_suite_focus=true#step:13:78