### PR TITLE
ENH: Allow initial dot for BIDS extension entity

### DIFF
--- a/_episodes/preprocessing.md
+++ b/_episodes/preprocessing.md
@@ -53,7 +53,10 @@ image to use later on, as well as the second inversion from the anatomical
 acquisition for brainmasking purposes.
 
 ~~~
+import bids
 from bids.layout import BIDSLayout
+
+bids.config.set_option('extension_initial_dot', True)
 
 layout = BIDSLayout("../../data/ds000221", validate=False)
 

--- a/code/preprocessing.ipynb
+++ b/code/preprocessing.ipynb
@@ -33,7 +33,10 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
+    "import bids\n",
     "from bids.layout import BIDSLayout\n",
+    "\n",
+    "bids.config.set_option('extension_initial_dot', True)\n",
     "\n",
     "layout = BIDSLayout(\"../data/ds000221\", validate=False)\n",
     "\n",


### PR DESCRIPTION
Allow initial dot for BIDS extension entity.

Fixes:
```
FutureWarning: The 'extension' entity currently excludes the leading dot ('.').
As of version 0.14.0, it will include the leading dot.
To suppress this warning and include the leading dot,
 use `bids.config.set_option('extension_initial_dot', True)`.
  warnings.warn("The 'extension' entity currently excludes the leading dot ('.'). "
```