### PR TITLE
[BUG] Add libgl1-mesa-glx for binder visualization

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,1 +1,2 @@
 tree
+libgl1-mesa-glx


### PR DESCRIPTION
Added `libgl1-mesa-glx` to the `apt.txt` for binder. This fixes the visualization error with fury, but increases the build time for the binder notebook. 

Tested it by spinning up a Binder notebook using the `fix_lib_error` branch.