### PR TITLE
[ENH] export utils to PYTHONPATH

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -6,3 +6,6 @@ jupyter nbextension enable exercise2/main
 osf -p cmq8a fetch ds000221_subject/ds000221_sub-010006.zip data/ds000221_sub-010006.zip
 unzip data/ds000221_sub-010006.zip -d data
 rm data/ds000221_sub-010006.zip
+
+# export pythonpath
+export PYTHONPATH=$PYTHONPATH:utils/


### PR DESCRIPTION
This adds the pythonpath to make use of the functions in `utils`. Going to merge this in as merging to another branch that has necessary libraries.