### PR TITLE
ENH: Switch to `JupyterLab`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Python is rapidly becoming the standard language for data analysis,
 visualization and automated workflow building. It is a free and open-source
 software that is relatively easy to pick up by new programmers. In addition,
 with Python packages such as `Jupyter` one can keep an interactive code journal
-of analysis - this is what we'll be using in the workshop. Using Jupyter
+of analysis - this is what we'll be using in the workshop. Using `Jupyter`
 notebooks allows you to keep a record of all the steps in your analysis,
 enabling transparency and ease of code sharing.
 

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -95,11 +95,10 @@ limitations of current methods.
 
 ## Technical tips and tricks
 
-* Be clear about the purpose and convenience of using [Jupyter Notebook] to
-teach the lesson. Allow some time at the beginning of the day to provide an
-overview of how using the learned tools would be translated to a more formal
-dMRI data analysis setting once a research aspect or analysis has been
-consolidated.
+* Be clear about the purpose and convenience of using [JupyterLab] to teach the
+lesson. Allow some time at the beginning of the day to provide an overview of
+how using the learned tools would be translated to a more formal dMRI data
+analysis setting once a research aspect or analysis has been consolidated.
 * Provide a broad overview of the software tools and packages used throughout
 the lesson, and the convenience of each of them.
 * Be sure to link the tools with their corresponding documentation pages.

--- a/_includes/lesson_links.md
+++ b/_includes/lesson_links.md
@@ -13,7 +13,7 @@
 [Git]: https://git-scm.com/
 [IPython]: https://ipython.org/index.html
 [Jupyter]: https://jupyter.org/
-[Jupyter Notebook]: https://jupyter-notebook.readthedocs.io/en/stable/
+[JupyterLab]: https://jupyterlab.readthedocs.io/en/latest/
 [lesson-github]: https://github.com/carpentries-incubator/SDC-BIDS-dMRI
 [Matplotlib]: https://matplotlib.org/
 [MRtrix]: https://www.mrtrix.org/

--- a/setup.md
+++ b/setup.md
@@ -2,13 +2,15 @@
 title: Setup
 ---
 
-This lesson uses [Jupyter Notebook] as a web-based interactive computational
-environment for learning. The `Jupyter Notebooks` can be run through [Binder],
-which builds a computing environment with all of the necessary software
-pre-installed. However, users may choose to run the notebooks locally. In that
-case, there are several pieces of software that must be installed. Although the
-main components required are `Python`-based, there are a few additional
-non-`Python` tools required.
+This lesson uses [JupyterLab] as a web-based interactive computational
+environment for learning. `JupyterLab` integrates a text editor, a terminal and
+`Jupyter Notebooks` through a single user-friendly interface, which will be
+used to run any code for the lesson. The `JupyterLab` instance and all of the
+necessary software have already been pre-installed on [Binder]. Users may
+choose to use this platform to get up and running much quicker, or may choose
+to run the notebooks locally. If running locally, there are several pieces of
+software that must be installed. Although the main components required are
+`Python`-based, there are a few additional non-`Python` tools required.
 
 Instructors should allocate some time to have all components installed.
 
@@ -27,7 +29,7 @@ to be installed locally in this case; it suffices to click on the
 
 ## Local
 
-If users choose to run the `Jupyter Notebooks` locally, the following
+If users choose to run the `Jupyter` notebooks locally, the following
 dependencies will need to be installed:
 
 - [ANTs] : used to register different anatomical data.
@@ -154,11 +156,11 @@ $ ipython notebook
 if using `IPython`, and running:
 
 ~~~
-jupyter notebook
+jupyter-lab
 ~~~
 {: .language-bash}
 
-if using `Jupyter`.
+if using `JupyterLab`.
 
 In either case, the commands will print some information about the notebook
 server in the terminal, and a web browser will be opened to the URL of the web


### PR DESCRIPTION
Switch to `JupyterLab`: change mentions in documentation from `Jupyter
Notebooks` to `JupyterLab`.