### PR TITLE
turn katex on

### DIFF
--- a/_episodes/diffusion_tensor_imaging.md
+++ b/_episodes/diffusion_tensor_imaging.md
@@ -11,6 +11,7 @@ objectives:
 keypoints:
 - "DTI is one of the simplest and most common models used"
 - "Provides information to infer characteristics of axonal fibres"
+math: true
 ---
 
 {% include base_path.html %}


### PR DESCRIPTION
@jhlegarreta following up from https://github.com/carpentries/carpentries-theme/issues/22#issuecomment-976865274, to enable KaTeX, `math: true` must be added to the yaml header for the episode page. Thanks!