### PR TITLE
ENH: Remove Python package cache restore in GHA workflow

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -96,15 +96,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Cache Python package install
-      uses: actions/cache@v2
-      id: cache
-      with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-            ${{ env.pythonLocation }}-
-
     - name: Install Python requirements
       if: steps.cache.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
Remove Python package cache restore in GHA workflow. Using the cache is
being problematic every time the `Install Python requirements` step of
the GHA is modified. Although the cache is removed after 7 days if it is
not accessed, it is impractical to need to wait for 7 days when a change
to the above step is done,
https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy

and it might even be a show-stopper when multiple changes need to be
made and tested that depend on changes to he requirements:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/runs/5434181049?check_suite_focus=true#step:6:12

Also, installing the Python dependencies is not the most lengthy step
when compared to installing `FSL`, which, according to the GHA logs, may
take between 45 minutes to 1h30. Also we are not being able to
effectively restore the FSL cache for now:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/runs/5434181049?check_suite_focus=true#step:6:12

So although waiting for ~2h to see the builds is relatively long for the
size of our code, given that we are not exceeding the GHA time limit, it
seems reasonable to drop the Python package install cache step.
