### PR TITLE
ENH: Prefer `nbmake` plugin for testing notebooks

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -101,7 +101,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest nbval
+        pip install pytest nbmake
 
     - name: Download data
       run: |
@@ -116,9 +116,9 @@ jobs:
       run: |
         export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}`
         export PATH=/opt/fsl/bin:/opt/ants:$PATH
-        pytest --nbval-lax -v code/introduction.ipynb
-        pytest --nbval-lax -v code/preprocessing.ipynb
-        pytest --nbval-lax -v code/diffusion_tensor_imaging.ipynb
-        pytest --nbval-lax -v code/constrained_spherical_deconvolution.ipynb
-        pytest --nbval-lax -v code/deterministic_tractography.ipynb
-        pytest --nbval-lax -v code/probabilistic_tractography.ipynb
+        pytest --nbmake -v code/introduction.ipynb
+        pytest --nbmake --nbmake-timeout=5400 -v code/preprocessing.ipynb
+        pytest --nbmake -v code/diffusion_tensor_imaging.ipynb
+        pytest --nbmake -v code/constrained_spherical_deconvolution.ipynb
+        pytest --nbmake -v code/deterministic_tractography.ipynb
+        pytest --nbmake -n=2 -v code/probabilistic_tractography.ipynb


### PR DESCRIPTION
Prefer using the `nbmake` plugin over `nbval` for testing notebooks.

`nbval`'s `timeout` flag to explicitly set the cell execution time is
not working properly, and most `preprocessing` notebook cells were not
being run.

Documentation:
https://pypi.org/project/nbmake/