### PR TITLE
ENH: Pin `matplotlib` package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dipy==1.3.0
 fury==0.6.1
-matplotlib
+matplotlib==3.5.3
 nilearn==0.7.0
 osfclient==0.0.5
 pybids==0.14.0


### PR DESCRIPTION
Pin `matplotlib` package version.

Fixes:
```
ImportError: cannot import name 'get_renderer' from 'matplotlib.tight_layout'
(/opt/hostedtoolcache/Python/3.9.15/x64/lib/python3.9/site-packages/matplotlib/tight_layout.py)
```

raised at:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/runs/3298335648/jobs/5440315644#step:13:132