### PR TITLE
ENH: Update actions versions to use `Node.js 16`

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Cache Ubuntu dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /var/lib/apt
         key: apt-cache-v1
@@ -52,7 +52,7 @@ jobs:
                              libxt6
 
     - name: Cache ANTs install
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /opt/ants
         key: ants-v1
@@ -67,7 +67,7 @@ jobs:
         fi
 
     - name: Cache FSL install
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /opt/fsl
         key: fsl-v2
@@ -84,7 +84,7 @@ jobs:
         fi
 
     - name: Checkout GitHub repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies for headless display
       run: |
@@ -92,7 +92,7 @@ jobs:
 
     # Run with multiple Python versions
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Update actions versions to use `Node.js 16`.

Fixes:
```
Node.js 12 actions are deprecated.
For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/cache, actions/checkout, actions/setup-python
```

raised for example in
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/runs/3303231018