### PR TITLE
ENH: Update DIPY and FURY

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dipy==1.3.0
-fury==0.6.1
+dipy==1.4.1
+fury==0.7.1
 matplotlib==3.5.3
 nilearn==0.7.0
 osfclient==0.0.5


### PR DESCRIPTION
Update DIPY version to 1.4.1 and FURY to 1.7.1.

Fixes errors related to NumPy type discontinued types:
```
AttributeError: module 'numpy' has no attribute 'float'
```

and
```
AttributeError: module 'numpy' has no attribute 'bool'
```

Raised for example in:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/runs/3773484312/jobs/6414959616#step:13:102
and
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/runs/3776245758/jobs/6419403735#step:13:191

Documentation:
https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations