### PR TITLE
BUG: Fix package dependency spec in `Binder` when using `pip`

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -20,4 +20,4 @@ dependencies:
   - seaborn
 
   - pip:
-      - pybids=0.14.0
+      - pybids==0.14.0


### PR DESCRIPTION
Fix package dependency spec in `Binder` when using `pip`.

Fixes:
```
Installing pip dependencies: ...working... Pip subprocess error:
ERROR: Invalid requirement: 'pybids=0.14.0' (from line 1 of /home/jovyan/binder/condaenv.ulzt7wnj.requirements.txt)
Hint: = is not a valid operator. Did you mean == ?

Ran pip subprocess with arguments:
['/srv/conda/envs/notebook/bin/python', '-m', 'pip', 'install', '-U', '-r', '/home/jovyan/binder/condaenv.ulzt7wnj.requirements.txt', '--exists-action=b']
Pip subprocess output:

failed

CondaEnvException: Pip failed

time: 202.640
```

Raised in:
blob:https://mybinder.org/344f60b1-514e-4043-8d8e-95722289a9b1
    
(include the `blob` tag when accessing the URL)