### PR TITLE
ENH: Bump `DIPY` to version 1.7.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.8.*
   - pip
   - git
-  - dipy=1.5.0
+  - dipy=1.7.0
   - fury=0.7.1
   - jupyter_contrib_nbextensions
   - matplotlib=3.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dipy==1.5.0
+dipy==1.7.0
 fury==0.7.1
 matplotlib==3.5.3
 nilearn==0.7.0


### PR DESCRIPTION
Bump `DIPY` to version 1.7.0.

Previous `DIPY` versions were using `NumPy`'s testing features relying on `nose`, which was deprecated in release 1.25.0.

Relevant `NumPy` documentation:
https://github.com/numpy/numpy/blob/dabb12ec5c27846b1ded065b5e61eabb89d029ed/doc/source/release/1.25.0-notes.rst?plain=1#L166 https://github.com/numpy/numpy/blob/dabb12ec5c27846b1ded065b5e61eabb89d029ed/doc/source/release/1.25.0-notes.rst?plain=1#L188

Commit in `DIPY` removing `NumPy`'s `nose` testing features: https://github.com/dipy/dipy/pull/2788/commits/d4216cee48a6c08ec97a3ac46a725f582a1fae46

Fixes:
```
ImportError                               Traceback (most recent call last)
Cell In[1], line 1
----> 1 from dipy.io.gradients import read_bvals_bvecs
      2 from dipy.core.gradients import gradient_table
      4 gt_bvals, gt_bvecs = read_bvals_bvecs(bval, bvec)

File /opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/dipy/__init__.py:41
     38 from .testing import setup_test
     40 # Test callable
---> 41 from numpy.testing import Tester
     42 test = Tester().test
     43 bench = Tester().bench

ImportError: cannot import name 'Tester' from 'numpy.testing'
(/opt/hostedtoolcache/Python/3.10.12/x64/lib/python3.10/site-packages/numpy/testing/__init__.py)
```

raised, for example, in:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/runs/5593859841/jobs/10228037219#step:13:74