### PR TITLE
ENH: Clean up `FSL` installer download step

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -90,9 +90,10 @@ jobs:
       run: |
         if [[ ! -d "${FSLPATH}" ]]; then
           sudo mkdir -p $FSLPATH
-          curl https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py -o ${{ github.workspace }}/../fslinstaller.py -s
-          python ${{ github.workspace }}/../fslinstaller.py -d ${FSLPATH} -V ${FSLVERSION} -o
+          curl https://fsl.fmrib.ox.ac.uk/fsldownloads/fslconda/releases/fslinstaller.py -o /tmp/fslinstaller.py -s
+          python /tmp/fslinstaller.py -d ${FSLPATH} -V ${FSLVERSION} -o
           sudo rm -rf ${FSLPATH}/data/atlases
+          rm /tmp/fslinstaller.py
         fi
 
     - name: Checkout GitHub repository


### PR DESCRIPTION
Clean up `FSL` installer download step:
- Change `FSL` installer download directory to separate it from the github workspace/code checkout directory.
- Remove the file once the installation has finished.