### PR TITLE
STYLE: Allow rendering LaTeX math syntax: intro and preproc episodes

### DIFF
--- a/_episodes/introduction.md
+++ b/_episodes/introduction.md
@@ -15,6 +15,7 @@ directional sensitivity)"
 this sensitivity, each volume of the 4D image is sensitive to a particular
 direction"
 start: true
+math: true
 ---
 
 {% include base_path.html %}

--- a/_episodes/preprocessing.md
+++ b/_episodes/preprocessing.md
@@ -11,6 +11,7 @@ objectives:
 keypoints:
 - "Many different preprocessing pipelines, dependent on how data is acquired"
 start: true
+math: true
 ---
 
 {% include base_path.html %}


### PR DESCRIPTION
Allow rendering LaTeX math syntax in introduction and preprocessing episodes.

Follow-up to commit 578080e5b971d397c9d7f99ff0469c318721d1cc.