### PR TITLE
ENH: Set up correctly branches filter in build, test GHA workflow file

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -2,7 +2,7 @@ name: Build, test
 
 on:
   push:
-    branch: main
+    branches: ['main']
   pull_request:
 
 # Allow a subsequently queued workflow run to interrupt previous runs


### PR DESCRIPTION
Set up correctly branches filter in build, test GHA workflow file: use `branches` instead of `branch` to filter git branches.

Fixes:
```
Schema validation: Property 'branch' is not allowed
```

Relevant documentation:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters