### PR TITLE
ENH: Add Python 3.11 to the CI build matrix

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     env:
       ANTSPATH: /opt/ants
       FSLPATH: /opt/fsl


### PR DESCRIPTION
Add Python 3.11 to the CI build matrix.