### PR TITLE
ENH: Fix website build deployment status badge workflow target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Introduction to dMRI
 
 [![Build Status](https://github.com/carpentries-incubator/SDC-BIDS-dMRI/workflows/Build,%20test/badge.svg)](https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions?query=workflow%3A"Build%2C+test")
-[![Website Check Status](https://github.com/carpentries-incubator/SDC-BIDS-dMRI/workflows/Website/badge.svg)](https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/workflows/website.yml?query=workflow%3AWebsite)
+[![Website Check Status](https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/workflows/pages/pages-build-deployment/badge.svg?branch=gh-pages)](https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/workflows/pages/pages-build-deployment)
 [![Create a Slack Account with us][create_slack_svg]][slack_heroku_invite]
 [![Slack Status][slack_channel_status]][slack_channel_url]
 [![Binder][binder_svg]][binder_url]


### PR DESCRIPTION
Fix website build deployment status badge workflow target after the transition to the Carpentries Workbench infrastructure.