### PR TITLE
ENH: Increase cell timeout value for preprocessing episode

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -128,7 +128,7 @@ jobs:
         export PYTHONPATH=$PYTHONPATH:`realpath ${{ github.workspace }}`
         export PATH=$FSLPATH/bin:$ANTSPATH:$PATH
         pytest --nbval-lax -v code/introduction.ipynb
-        pytest --nbval-lax -v code/preprocessing.ipynb
+        pytest --nbval-cell-timeout=3000 -v code/preprocessing.ipynb
         pytest --nbval-lax -v code/diffusion_tensor_imaging.ipynb
         pytest --nbval-lax -v code/constrained_spherical_deconvolution.ipynb
         pytest --nbval-lax -v code/deterministic_tractography.ipynb


### PR DESCRIPTION
Increase cell timeout value for preprocessing episode to 3000 seconds to allow successful completion of tasks.