### PR TITLE
ENH: Require Numpy major version smaller than 2

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - matplotlib=3.5.3
   - nibabel
   - nilearn=0.7.0
-  - numpy
+  - numpy<2
   - osfclient=0.0.5
   - pandas
   - seaborn

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ dipy==1.7.0
 fury==0.7.1
 matplotlib==3.5.3
 nilearn==0.7.0
+numpy<2
 osfclient==0.0.5
 pybids==0.14.0


### PR DESCRIPTION
Require Numpy major version smaller than 2: with the recent release of Numpy 2 a number of dependencies have started to fail, so require Numpy major versions smaller than 2 until dependencies adapt to Numpy 2.0.

Fixes:
```
AttributeError  Traceback (most recent call last)
AttributeError: _ARRAY_API not found
```

reported for example in:
https://github.com/carpentries-incubator/SDC-BIDS-dMRI/actions/runs/9655229240/job/26630796981#step:13:65

Numpy 2.0.0 release notice:
https://numpy.org/news/#numpy-200-released